### PR TITLE
Refactor Popover story to use Storybook args pattern

### DIFF
--- a/components/Popover/Popover.stories.tsx
+++ b/components/Popover/Popover.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useArgs } from "storybook/preview-api";
 import { Popover } from "./Popover";
 import { Button, Card, Text, Page, Flex, Stack } from "doom-design-system";
 import { useState } from "react";
@@ -19,17 +20,23 @@ export default meta;
 type Story = StoryObj<typeof Popover>;
 
 export const Default: Story = {
-  render: () => {
-    const [isOpen, setIsOpen] = useState(false);
+  args: {
+    isOpen: false,
+  },
+  render: function Render(args) {
+    const [{ isOpen }, updateArgs] = useArgs();
 
     return (
       <Page>
         <Flex align="center" justify="center" style={{ minHeight: "400px" }}>
           <Popover
+            {...args}
             isOpen={isOpen}
-            onClose={() => setIsOpen(false)}
+            onClose={() => updateArgs({ isOpen: false })}
             trigger={
-              <Button onClick={() => setIsOpen(!isOpen)}>Click me</Button>
+              <Button onClick={() => updateArgs({ isOpen: !isOpen })}>
+                Click me
+              </Button>
             }
             content={
               <Card style={{ padding: "1rem", width: "200px" }}>


### PR DESCRIPTION
## Summary
Refactored the Popover `Default` story to use Storybook's `useArgs` hook instead of explicit `useState` for managing the `isOpen` state.

## Changes
- Added `useArgs` import from `storybook/preview-api`
- Defined `isOpen: false` in the story's `args`
- Replaced `useState` with `useArgs()` hook
- Updated state handlers to use `updateArgs()` instead of `setIsOpen()`

This follows Storybook's recommended pattern for controlled components, which allows the state to be managed through Storybook's args system and makes it controllable from the Storybook UI.

See: https://storybook.js.org/docs/writing-stories/args

## Test plan
- [x] Storybook builds successfully
- [x] Default story renders correctly
- [x] Popover opens/closes as expected
- [x] isOpen arg is controllable from Storybook controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)