### PR TITLE
chore(plugin): bump to 1.1.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "doom-design-system",
   "description": "AI skills, agents, hooks, and commands for the Doom Design System — neubrutalist React component library. Gives AI agents deep knowledge of every component, A2UI protocol, design tokens, and coding standards.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Eduardo Ornelas"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doom-design-system",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doom-design-system",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doom-design-system",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Neubrutalist and comic book inspired design system",
   "sideEffects": [
     "**/*.css",


### PR DESCRIPTION
Bumps the Claude Code plugin version (\`.claude-plugin/plugin.json\`) from 1.0.0 → 1.1.0 so consumers using the plugin pick up the new skills and updated docs.

Significant additions since 1.0.0:

**New skills**
- \`lib/filter.md\` — covers both the headless filter AST (\`Filter\`, \`evaluateFilter\`, \`OPERATORS\`) and the doom-styled UI components (\`FilterBuilder\`, \`FilterDraft\`, \`draftToFilter\`)

**Component-builder skill overhaul**
- Spec-driven mode (\`/new-component --spec path/to/spec.md\`)
- Compound component template (inline context, baseId, controlled/uncontrolled pattern)
- Mixin enforcement table + doom design judgment calls
- Test/story coverage checklists
- Doom philosophy narrative

**Skill accuracy fixes**
- Mixin names: \`base-interactive\`→\`control\`, \`brutalist-hover\`→\`hover\`, \`brutalist-shadow\`→\`shadow-directional\`
- Token names: \`--spacing-*\`→\`--space-*\`, \`--border-width\`→\`--surface-border-width\`, \`--shadow-hard\`→\`--shadow-md\`
- forwardRef guidance: was \"always\", now \"only for form controls\"

**New components covered**
- ToggleGroup, Rating skill docs
- Checkbox doc updated for new indeterminate prop

**Existing component skills updated**
- Sidebar (profile footer popover, width 240px)
- Page (header-zone alignment, no backdrop blur)
- Popover (new right-*/left-* placements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)