### PR TITLE
feat(Chart): support negative line values and configurable axis bounds

### DIFF
--- a/components/Chart/Chart.domains.browser.test.tsx
+++ b/components/Chart/Chart.domains.browser.test.tsx
@@ -1,0 +1,413 @@
+import "../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { DesignSystemProvider } from "../../DesignSystemProvider";
+import { Chart } from "./Chart";
+import { useChartContext } from "./context";
+import type { Store } from "./state/store/chart.store";
+
+type Domain = readonly [number | null, number | null];
+const rows = [
+  { x: 0, y: -9 },
+  { x: 1, y: -3 },
+  { x: 2, y: 4 },
+  { x: 3, y: 11 },
+];
+const settle = () => new Promise((resolve) => setTimeout(resolve, 200));
+const tooltip = (host: Element) =>
+  host.querySelector("[data-chart-tooltip]")?.textContent ?? "";
+const points = (host: Element) =>
+  Array.from(
+    host.querySelectorAll<SVGCircleElement>(".chart-line-series circle"),
+  );
+const root = (host: Element) =>
+  host.querySelector<HTMLElement>("[data-chart-container]")!;
+
+afterEach(cleanup);
+
+function Capture({ save }: { save: (store: Store) => void }) {
+  save(useChartContext().chartStore);
+  return null;
+}
+
+interface ExampleProps {
+  xDomain?: Domain;
+  yDomain?: Domain;
+  width?: number;
+  save: (store: Store) => void;
+}
+function Example({ width = 600, save, ...domains }: ExampleProps) {
+  return (
+    <DesignSystemProvider>
+      <Chart.Root
+        {...domains}
+        d3Config={{ showDots: true }}
+        data={rows}
+        style={{ width, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      >
+        <Chart.Plot>
+          <Capture save={save} />
+          <Chart.Series type="line" />
+          <Chart.Axis />
+        </Chart.Plot>
+      </Chart.Root>
+    </DesignSystemProvider>
+  );
+}
+
+describe("Chart axis domains in a real browser", () => {
+  it.each([
+    ["mixed", [-9, -3, 4, 11]],
+    ["negative-only", [-19, -13, -7, -1]],
+  ] as const)(
+    "keeps default %s line geometry visible and hoverable",
+    async (_, values) => {
+      const { container } = render(
+        <DesignSystemProvider>
+          <Chart
+            d3Config={{ showDots: true }}
+            data={values.map((y, x) => ({ x, y }))}
+            style={{ width: 600, height: 360 }}
+            type="line"
+            x="x"
+            y="y"
+          />
+        </DesignSystemProvider>,
+      );
+      await settle();
+      const svg = container.querySelector<SVGSVGElement>("[data-chart-plot]")!;
+      const bounds = svg.getBoundingClientRect();
+      const marks = points(container);
+      expect(marks).toHaveLength(4);
+      const centers = marks.map((mark) => {
+        const box = mark.getBoundingClientRect();
+        return { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+      });
+      for (const center of centers) {
+        expect(center.x).toBeGreaterThanOrEqual(bounds.left);
+        expect(center.x).toBeLessThanOrEqual(bounds.right);
+        expect(center.y).toBeGreaterThanOrEqual(bounds.top);
+        expect(center.y).toBeLessThanOrEqual(bounds.bottom);
+      }
+      expect(centers[0].y - centers[3].y).toBeGreaterThan(100);
+      const line = container.querySelector<SVGPathElement>(
+        'path[aria-roledescription="line"]',
+      )!;
+      expect(line.getTotalLength()).toBeGreaterThan(100);
+      await userEvent.hover(marks[1]);
+      await expect.poll(() => tooltip(container)).toContain(`:${values[1]}`);
+    },
+  );
+
+  it("uses exact explicit endpoints, null auto endpoints, and automatic fallback for invalid domains", async () => {
+    let store!: Store;
+    const save = (value: Store) => {
+      store = value;
+    };
+    const { rerender } = render(<Example save={save} />);
+    await settle();
+    const automaticX = store.getState().scales.x!.domain();
+    const automaticY = store.getState().scales.y!.domain();
+    rerender(
+      <Example save={save} xDomain={[-0.35, 2.65]} yDomain={[-7.25, 8.75]} />,
+    );
+    await expect
+      .poll(() => store.getState().scales.x!.domain())
+      .toEqual([-0.35, 2.65]);
+    expect(store.getState().scales.y!.domain()).toEqual([-7.25, 8.75]);
+    rerender(
+      <Example save={save} xDomain={[null, 2.65]} yDomain={[-7.25, null]} />,
+    );
+    await expect
+      .poll(() => store.getState().scales.y!.domain())
+      .toEqual([-7.25, automaticY[1]]);
+    expect(store.getState().scales.x!.domain()).toEqual([automaticX[0], 2.65]);
+    for (const invalid of [
+      [4, -4],
+      [2, 2],
+      [NaN, 10],
+      [-10, Infinity],
+    ] as const) {
+      rerender(<Example save={save} xDomain={invalid} yDomain={invalid} />);
+      await expect
+        .poll(() => store.getState().scales.x!.domain())
+        .toEqual(automaticX);
+      expect(store.getState().scales.y!.domain()).toEqual(automaticY);
+    }
+  });
+
+  it("drops offplot hover and keyboard targets when domains change, then restores them", async () => {
+    let store!: Store;
+    const save = (value: Store) => {
+      store = value;
+    };
+    const { container, rerender } = render(
+      <Example save={save} xDomain={[-1, 4]} yDomain={[-12, 12]} />,
+    );
+    await settle();
+    await userEvent.hover(points(container)[0]);
+    await expect.poll(() => tooltip(container)).toContain(":-9");
+    // One point is outside x, another is inside x but outside y.
+    rerender(<Example save={save} xDomain={[0.5, 3.5]} yDomain={[-5, 6]} />);
+    await expect.poll(() => tooltip(container)).not.toContain(":-9");
+    await userEvent.hover(points(container)[1]);
+    await expect.poll(() => tooltip(container)).toContain(":-3");
+    root(container).focus();
+    for (let i = 0; i < 6; i++) {
+      await userEvent.keyboard("{ArrowRight}");
+      const text = tooltip(container);
+      expect(text).toMatch(/:(-3|4)(?:\D|$)/);
+      expect(text).not.toContain(":-9");
+      expect(text).not.toContain(":11");
+    }
+    // Real hit-testing must respect the SVG clip, even though the path and
+    // circle geometry may legitimately extend beyond it.
+    const offplot = points(container)[3];
+    const box = offplot.getBoundingClientRect();
+    expect(
+      document.elementsFromPoint(box.x + box.width / 2, box.y + box.height / 2),
+    ).not.toContain(offplot);
+    expect(store.getState().scales.x!.domain()).toEqual([0.5, 3.5]);
+    rerender(<Example save={save} xDomain={[-1, 4]} yDomain={[-12, 12]} />);
+    await settle();
+    await userEvent.hover(points(container)[3]);
+    await expect.poll(() => tooltip(container)).toContain(":11");
+    root(container).focus();
+    await userEvent.keyboard("{Escape}{ArrowRight}");
+    await expect.poll(() => tooltip(container)).toContain(":-9");
+  });
+
+  it("keeps domains and hover independent across charts, resize, and remount", async () => {
+    let first!: Store;
+    let second!: Store;
+    const saveFirst = (value: Store) => {
+      first = value;
+    };
+    const saveSecond = (value: Store) => {
+      second = value;
+    };
+    const dashboard = (width: number, key = "original") => (
+      <div style={{ display: "flex" }}>
+        <Example
+          key={key}
+          save={saveFirst}
+          width={width}
+          xDomain={[-1, 4]}
+          yDomain={[-12, 12]}
+        />
+        <Example
+          save={saveSecond}
+          width={550}
+          xDomain={[-2, 5]}
+          yDomain={[-20, 20]}
+        />
+      </div>
+    );
+    const { container, rerender } = render(dashboard(600));
+    await settle();
+    const initialWidth = first.getState().dimensions.innerWidth;
+    for (const [width, key] of [
+      [500, "original"],
+      [600, "remounted"],
+    ] as const) {
+      rerender(dashboard(width, key));
+      await settle();
+      if (width === 500) {
+        expect(first.getState().dimensions.innerWidth).toBeLessThan(
+          initialWidth,
+        );
+      }
+      expect(first.getState().scales.x!.domain()).toEqual([-1, 4]);
+      expect(first.getState().scales.y!.domain()).toEqual([-12, 12]);
+      expect(second.getState().scales.x!.domain()).toEqual([-2, 5]);
+      expect(second.getState().scales.y!.domain()).toEqual([-20, 20]);
+      const charts = container.querySelectorAll<HTMLElement>(
+        "[data-chart-container]",
+      );
+      const clipIds = Array.from(charts, (chart, index) => {
+        const clipped = points(chart)[1].closest("[clip-path]")!;
+        expect(clipped).not.toBeNull();
+        expect(getComputedStyle(clipped).clipPath).not.toBe("none");
+        const reference = clipped.getAttribute("clip-path")!;
+        const id = reference.match(/url\(#(.+)\)/)![1];
+        const clip = chart.querySelector<SVGClipPathElement>(
+          `clipPath[id="${id}"]`,
+        )!;
+        expect(clip).not.toBeNull();
+        expect(document.getElementById(id)).toBe(clip);
+        const rect = clip.querySelector("rect")!;
+        const dimensions = (index === 0 ? first : second).getState().dimensions;
+        expect(Number(rect.getAttribute("width"))).toBeCloseTo(
+          dimensions.innerWidth,
+        );
+        expect(Number(rect.getAttribute("height"))).toBeCloseTo(
+          dimensions.innerHeight,
+        );
+        return id;
+      });
+      expect(new Set(clipIds).size).toBe(2);
+      await userEvent.hover(points(charts[0])[1]);
+      await expect.poll(() => tooltip(charts[0])).toContain(":-3");
+      expect(tooltip(charts[1])).toBe("");
+      await userEvent.hover(points(charts[1])[2]);
+      await expect.poll(() => tooltip(charts[1])).toContain(":4");
+      await expect.poll(() => tooltip(charts[0])).toBe("");
+      await userEvent.unhover(points(charts[1])[2]);
+    }
+  });
+
+  it("does not include an offplot series candidate in the default shared tooltip", async () => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart.Root
+          d3Config={{ showDots: true }}
+          data={[{ x: 1, y: 2 }]}
+          style={{ width: 600, height: 360 }}
+          type="line"
+          x="x"
+          xDomain={[0, 2]}
+          y="y"
+          yDomain={[-5, 6]}
+        >
+          <Chart.Plot>
+            <Chart.Series label="Visible" type="line" />
+            <Chart.Series
+              data={[{ x: 1, y: 20 }]}
+              label="Outside"
+              type="line"
+            />
+          </Chart.Plot>
+        </Chart.Root>
+      </DesignSystemProvider>,
+    );
+    await settle();
+    await userEvent.hover(points(container)[0]);
+    await expect.poll(() => tooltip(container)).toContain("Visible:2");
+    expect(tooltip(container)).not.toContain("Outside");
+    root(container).focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect.poll(() => tooltip(container)).toContain("Visible:2");
+    expect(tooltip(container)).not.toContain("Outside");
+  });
+
+  it.each([false, true])(
+    "ignores category bounds and applies exact numeric bounds to signed bars (horizontal=%s)",
+    async (horizontal) => {
+      let store!: Store;
+      const { container } = render(
+        <DesignSystemProvider>
+          <Chart.Root
+            data={[
+              { category: "A", value: -8 },
+              { category: "B", value: 12 },
+            ]}
+            style={{ width: 600, height: 360 }}
+            type="bar"
+            x={horizontal ? "value" : "category"}
+            xDomain={horizontal ? [-10.5, 2.5] : [100, 200]}
+            y={horizontal ? "category" : "value"}
+            yDomain={horizontal ? [100, 200] : [-10.5, 2.5]}
+          >
+            <Chart.Plot>
+              <Capture
+                save={(value) => {
+                  store = value;
+                }}
+              />
+              <Chart.Series
+                orientation={horizontal ? "horizontal" : "vertical"}
+                type="bar"
+              />
+              <Chart.Axis />
+            </Chart.Plot>
+          </Chart.Root>
+        </DesignSystemProvider>,
+      );
+      await settle();
+      const scales = store.getState().scales;
+      expect((horizontal ? scales.x : scales.y)!.domain()).toEqual([
+        -10.5, 2.5,
+      ]);
+      expect((horizontal ? scales.y : scales.x)!.domain()).toEqual(["A", "B"]);
+      const bars = container.querySelectorAll<SVGPathElement>(".chart-bar");
+      expect(bars).toHaveLength(2);
+      const [negative, positive] = Array.from(bars, (bar) =>
+        bar.getBoundingClientRect(),
+      );
+      expect(horizontal ? negative.right : negative.top).toBeCloseTo(
+        horizontal ? positive.left : positive.bottom,
+      );
+      expect(
+        (horizontal ? positive.width : positive.height) /
+          (horizontal ? negative.width : negative.height),
+      ).toBeCloseTo(1.5);
+      await userEvent.hover(bars[0]);
+      await expect.poll(() => tooltip(container)).toContain(":-8");
+      // The positive bar's original center (value 6) lies beyond the upper
+      // bound 2.5. Its visible truncated portion must remain interactive.
+      expect(
+        document.elementsFromPoint(
+          positive.x + positive.width / 2,
+          positive.y + positive.height / 2,
+        ),
+      ).not.toContain(bars[1]);
+      // Aim at value 1.25, halfway through the visible [0, 2.5] portion;
+      // Playwright's default center lands in the clipped-out geometry.
+      await userEvent.hover(bars[1], {
+        position: {
+          x: horizontal ? positive.width * (1.25 / 12) : positive.width / 2,
+          y: horizontal
+            ? positive.height / 2
+            : positive.height * (1 - 1.25 / 12),
+        },
+      });
+      await expect.poll(() => tooltip(container)).toContain(":12");
+      root(container).focus();
+      await userEvent.keyboard(
+        horizontal
+          ? "{Escape}{ArrowDown}{ArrowDown}"
+          : "{Escape}{ArrowRight}{ArrowRight}",
+      );
+      await expect.poll(() => tooltip(container)).toContain(":12");
+    },
+  );
+});
+
+it.each([
+  ["automatic", { yDomain: [null, null] as const }],
+  ["invalid", { yDomain: [5, 5] as const }],
+  ["Y-only", { yDomain: [-20, 20] as const }],
+])(
+  "preserves full endpoint marks on the unaffected X axis with %s bounds",
+  async (_, domains) => {
+    const { container } = render(<Example save={() => {}} {...domains} />);
+    await settle();
+    const point = points(container)[0];
+    const box = point.getBoundingClientRect();
+    expect(
+      document.elementsFromPoint(box.left + 2, box.top + box.height / 2),
+    ).toContain(point);
+  },
+);
+
+it("keeps series identity stable when adding and removing axis bounds", async () => {
+  let store!: Store;
+  const save = (value: Store) => {
+    store = value;
+  };
+  const { rerender } = render(<Example save={save} />);
+  await settle();
+  const id = store.getState().processedSeries[0].id;
+  rerender(<Example save={save} yDomain={[-20, 20]} />);
+  await settle();
+  expect(store.getState().processedSeries[0].id).toBe(id);
+  rerender(<Example save={save} />);
+  await settle();
+  expect(store.getState().processedSeries[0].id).toBe(id);
+});

--- a/components/Chart/Chart.stories.browser.test.tsx
+++ b/components/Chart/Chart.stories.browser.test.tsx
@@ -58,3 +58,28 @@ for (const [Story, horizontal, expected] of [
     );
   });
 }
+
+for (const [name, Story] of [
+  ["signed line", composeStories(stories).SignedLineMetric],
+  ["shared fixed bounds", composeStories(stories).SharedFixedYBounds],
+] as const) {
+  it(`paints endpoint dots over the Y axis in the ${name} story`, async () => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Story />
+      </DesignSystemProvider>,
+    );
+    await expect
+      .poll(() => container.querySelector(".chart-line-series circle"))
+      .toBeTruthy();
+    for (const plot of container.querySelectorAll("[data-chart-plot]")) {
+      const point = plot.querySelector(".chart-line-series circle")!;
+      await expect.poll(() => plot.querySelectorAll(".domain").length).toBe(2);
+      const axis = plot.querySelectorAll(".domain")[1];
+      // SVG paints later siblings on top; axes ignore pointer events, so hit testing cannot detect this occlusion.
+      expect(
+        axis.compareDocumentPosition(point) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    }
+  });
+}

--- a/components/Chart/Chart.stories.module.scss
+++ b/components/Chart/Chart.stories.module.scss
@@ -1,4 +1,16 @@
 @layer doom.components {
+  .domainChart {
+    width: 100%;
+    min-width: 0;
+    height: 420px;
+  }
+
+  .domainComparison {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
+    gap: var(--space-6);
+  }
+
   .composition {
     container-type: inline-size;
   }

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -84,6 +84,121 @@ export const LineChart: Story = {
   },
 };
 
+const monthlyCashFlow = [
+  { month: "Jan", netCashFlow: -24 },
+  { month: "Feb", netCashFlow: -12 },
+  { month: "Mar", netCashFlow: 8 },
+  { month: "Apr", netCashFlow: 20 },
+  { month: "May", netCashFlow: -6 },
+  { month: "Jun", netCashFlow: 32 },
+];
+
+export const SignedLineMetric: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Monthly net cash flow crosses zero: negative values mean cash outflow and positive values mean cash inflow. Automatic Y bounds include zero and pad both signed extrema before rounding to readable ticks.",
+      },
+    },
+  },
+  render: () => (
+    <Chart.Root
+      className={storyStyles.domainChart}
+      d3Config={{
+        grid: true,
+        showDots: true,
+        xAxisLabel: "Month",
+        yAxisLabel: "Net cash flow (USD thousands)",
+      }}
+      data={monthlyCashFlow}
+      type="line"
+      x="month"
+      y="netCashFlow"
+    >
+      <Chart.Header
+        subtitle="USD thousands · negative = outflow · positive = inflow"
+        title="Monthly net cash flow"
+      />
+      <Chart.Plot>
+        <Chart.Grid />
+        <Chart.Cursor />
+        <Chart.Series label="Net cash flow (USD thousands)" type="line" />
+        <Chart.Axis />
+      </Chart.Plot>
+    </Chart.Root>
+  ),
+};
+
+const regionalRevenue = [
+  {
+    region: "North",
+    data: [
+      { month: "Jan", revenue: 62 },
+      { month: "Feb", revenue: 74 },
+      { month: "Mar", revenue: 86 },
+      { month: "Apr", revenue: 80 },
+    ],
+  },
+  {
+    region: "South",
+    data: [
+      { month: "Jan", revenue: 12 },
+      { month: "Feb", revenue: 24 },
+      { month: "Mar", revenue: 36 },
+      { month: "Apr", revenue: 30 },
+    ],
+  },
+];
+
+const sharedRevenueDomain = [0, 100] as const;
+
+export const SharedFixedYBounds: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Both regions use the same exact Y bounds of 0–100 USD thousands and equal chart heights. Their identical month-to-month changes have the same visual size, while the 50-thousand-dollar revenue gap stays visible. Independent automatic ranges would exaggerate the smaller region's changes.",
+      },
+    },
+  },
+  render: () => (
+    <div className={storyStyles.domainComparison}>
+      {regionalRevenue.map(({ region, data: revenue }) => (
+        <Chart.Root
+          key={region}
+          className={storyStyles.domainChart}
+          d3Config={{
+            grid: true,
+            showDots: true,
+            xAxisLabel: "Month",
+            yAxisLabel: "Revenue (USD thousands)",
+          }}
+          data={revenue}
+          type="line"
+          x="month"
+          y="revenue"
+          yDomain={sharedRevenueDomain}
+        >
+          <Chart.Header
+            subtitle="USD thousands · fixed Y range: 0–100"
+            title={`${region} region revenue`}
+          />
+          <Chart.Plot>
+            <Chart.Grid />
+            <Chart.Cursor />
+            <Chart.Series
+              label={`${region} revenue (USD thousands)`}
+              type="line"
+            />
+            <Chart.Axis />
+          </Chart.Plot>
+        </Chart.Root>
+      ))}
+    </div>
+  ),
+};
+
 export const AreaChart: Story = {
   args: {
     ...LineChart.args,

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -122,9 +122,9 @@ export const SignedLineMetric: Story = {
       />
       <Chart.Plot>
         <Chart.Grid />
-        <Chart.Cursor />
-        <Chart.Series label="Net cash flow (USD thousands)" type="line" />
         <Chart.Axis />
+        <Chart.Series label="Net cash flow (USD thousands)" type="line" />
+        <Chart.Cursor />
       </Chart.Plot>
     </Chart.Root>
   ),
@@ -186,12 +186,12 @@ export const SharedFixedYBounds: Story = {
           />
           <Chart.Plot>
             <Chart.Grid />
-            <Chart.Cursor />
+            <Chart.Axis />
             <Chart.Series
               label={`${region} revenue (USD thousands)`}
               type="line"
             />
-            <Chart.Axis />
+            <Chart.Cursor />
           </Chart.Plot>
         </Chart.Root>
       ))}

--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -31,6 +31,7 @@ export type { EngineEvent, InputSignal, InteractionCandidate } from "./engine";
 export { InputAction, InputSource } from "./engine";
 export type {
   Accessor,
+  AxisDomain,
   ChartProps,
   Config,
   ContextValue,

--- a/components/Chart/sensors/KeyboardSensor/KeyboardSensor.test.ts
+++ b/components/Chart/sensors/KeyboardSensor/KeyboardSensor.test.ts
@@ -5,15 +5,25 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { EngineEvent, InputAction } from "../../engine";
+import {
+  createChartStore,
+  registerSeries,
+  State,
+  updateChartDimensions,
+  updateChartMargin,
+  updateChartState,
+  upsertInteraction,
+} from "../../state/store/chart.store";
 import { SensorContext } from "../../types/events";
 import { InteractionChannel } from "../../types/interaction";
+import { d3 } from "../../utils/d3";
 import { KeyboardSensor } from "./KeyboardSensor";
 
 // =============================================================================
 // MOCK SETUP
 // =============================================================================
 
-const createMockContext = (): SensorContext => {
+const createMockContext = (overrides: Partial<State> = {}): SensorContext => {
   const interactions = new Map<string, unknown>();
   const mockData = [
     { x: 0, y: 10, id: "p0" },
@@ -34,9 +44,12 @@ const createMockContext = (): SensorContext => {
           x: "x",
           y: "y",
           dimensions: {
+            innerWidth: 100,
+            innerHeight: 100,
             margin: { left: 0, top: 0 },
           },
           interactions,
+          ...overrides,
         }),
       },
     })) as any,
@@ -173,4 +186,420 @@ describe("KeyboardSensor (Engine)", () => {
       }),
     );
   });
+});
+
+describe("KeyboardSensor plot domains", () => {
+  const key = (
+    sensor: ReturnType<typeof KeyboardSensor>,
+    ctx: SensorContext,
+    key = "ArrowRight",
+  ) => sensor(createMockEvent(InputAction.KEY, key), ctx);
+  const hover = (ctx: SensorContext) =>
+    ctx.getInteraction(InteractionChannel.PRIMARY_HOVER);
+
+  it("skips offplot and nonfinite centers in both directions without changing data indices", () => {
+    const ctx = createMockContext({
+      xDomain: [0, 10],
+      yDomain: [0, 100],
+      scales: {
+        x: d3.scaleLinear().domain([0, 10]).range([0, 100]),
+        y: d3.scaleLinear().domain([0, 100]).range([100, 0]),
+      },
+      data: [
+        { x: -1, y: 10 },
+        { x: 2, y: 20 },
+        { x: 3, y: 200 },
+        { x: 4, y: 40 },
+        { x: NaN, y: 5 },
+      ],
+    });
+    const sensor = KeyboardSensor();
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({ target: { dataIndex: 1 } });
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({ target: { dataIndex: 3 } });
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({ target: { dataIndex: 3 } });
+    key(sensor, ctx, "ArrowLeft");
+    expect(hover(ctx)).toMatchObject({ target: { dataIndex: 1 } });
+  });
+
+  it("keeps visible members of a slice and categories found only in later series", () => {
+    const ctx = createMockContext({
+      xDomain: [0, 10],
+      yDomain: [0, 100],
+      scales: {
+        x: d3.scaleLinear().domain([0, 10]).range([0, 100]),
+        y: d3.scaleLinear().domain([0, 100]).range([100, 0]),
+      },
+      processedSeries: [
+        {
+          id: "first",
+          type: "line",
+          xAccessor: "x",
+          yAccessor: "y",
+          data: [
+            { x: 1, y: 200 },
+            { x: 2, y: 20 },
+          ],
+        },
+        {
+          id: "later",
+          type: "line",
+          xAccessor: "x",
+          yAccessor: "y",
+          data: [
+            { x: 1, y: 10 },
+            { x: 3, y: 30 },
+          ],
+        },
+      ],
+    });
+    const sensor = KeyboardSensor();
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({
+      targets: [{ seriesId: "later", dataIndex: 0 }],
+    });
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({
+      targets: [{ seriesId: "first", dataIndex: 1 }],
+    });
+    key(sensor, ctx);
+    expect(hover(ctx)).toMatchObject({
+      targets: [{ seriesId: "later", dataIndex: 1 }],
+    });
+  });
+
+  it.each(["vertical", "horizontal"] as const)(
+    "uses clipped %s bar centers and skips fully outside stacks",
+    (orientation) => {
+      const horizontal = orientation === "horizontal";
+      const ctx = createMockContext({
+        xDomain: [0, 10],
+        yDomain: [0, 10],
+        scales: {
+          x: d3.scaleLinear().domain([0, 10]).range([0, 100]),
+          y: d3.scaleLinear().domain([0, 10]).range([100, 0]),
+        },
+        processedSeries: [
+          {
+            id: "bars",
+            type: "bar",
+            orientation,
+            xAccessor: "x",
+            yAccessor: "y",
+            barWidth: 20,
+            data: horizontal
+              ? [
+                  { x: 15, y: 5 },
+                  { x: 30, y: 5 },
+                ]
+              : [
+                  { x: 5, y: 15 },
+                  { x: 5, y: 30 },
+                ],
+            stackRanges: [
+              [5, 15],
+              [20, 30],
+            ],
+          },
+        ],
+      });
+      const sensor = KeyboardSensor();
+      key(sensor, ctx);
+      expect(hover(ctx)).toMatchObject({
+        target: {
+          dataIndex: 0,
+          coordinate: horizontal ? { x: 75, y: 50 } : { x: 50, y: 25 },
+          suppressMarker: true,
+        },
+      });
+      key(sensor, ctx);
+      expect(hover(ctx)).toMatchObject({ target: { dataIndex: 0 } });
+    },
+  );
+
+  it("clears stale hover when no points remain visible and Escape still works", () => {
+    const data = [{ x: 1, y: 10 }];
+    const ctx = createMockContext({
+      xDomain: [0, 10],
+      yDomain: [0, 100],
+      scales: {
+        x: d3.scaleLinear().domain([0, 10]).range([0, 100]),
+        y: d3.scaleLinear().domain([0, 100]).range([100, 0]),
+      },
+      data,
+    });
+    const sensor = KeyboardSensor();
+    key(sensor, ctx);
+    data[0].y = 200;
+    key(sensor, ctx);
+    expect(hover(ctx)).toBeNull();
+    key(sensor, ctx, "Escape");
+    expect(ctx.removeInteraction).toHaveBeenCalledWith(
+      InteractionChannel.PRIMARY_HOVER,
+    );
+  });
+
+  it("refreshes an active point against current scales and removes an offplot target", () => {
+    const store = createChartStore(
+      {
+        width: 100,
+        height: 100,
+        margin: { top: 0, right: 0, bottom: 0, left: 0 },
+      },
+      "x",
+      "y",
+    );
+    const datum = { x: 5, y: 5 };
+    const scales = {
+      x: d3.scaleLinear().domain([0, 10]).range([0, 100]),
+      y: d3.scaleLinear().domain([0, 10]).range([100, 0]),
+    };
+    store.setState({ data: [datum], scales, yDomain: [6, 10] });
+    upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+      targets: [{ data: datum, dataIndex: 0, coordinate: { x: 50, y: 50 } }],
+    });
+    scales.y.domain([6, 10]);
+    registerSeries(store, "line", [{ type: "line", x: "x", y: "y" }]);
+    expect(
+      store.getState().interactions.has(InteractionChannel.PRIMARY_HOVER),
+    ).toBe(false);
+  });
+});
+
+describe("hover refresh on domain updates", () => {
+  const config = {
+    width: 130,
+    height: 120,
+    margin: { left: 20, right: 10, top: 10, bottom: 10 },
+  };
+
+  it("reprojects retained slice members and removes the hover when both axes exclude them", () => {
+    const store = createChartStore(config, "x", "y");
+    const data = [
+      { x: 2, y: 8 },
+      { x: 8, y: 2 },
+    ];
+    const dimensions = store.getState().dimensions;
+    updateChartState(store, {
+      data,
+      dimensions,
+      xDomain: [0, 10],
+      yDomain: [0, 10],
+    });
+    upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+      targets: data.map((datum, dataIndex) => ({
+        data: datum,
+        dataIndex,
+        coordinate: { x: 0, y: 0 },
+      })),
+    });
+    updateChartState(store, {
+      data,
+      dimensions,
+      xDomain: [0, 10],
+      yDomain: [0, 5],
+    });
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toMatchObject({
+      targets: [{ dataIndex: 1, coordinate: { x: 100, y: 70 } }],
+      target: { dataIndex: 1 },
+    });
+    updateChartState(store, {
+      data,
+      dimensions,
+      xDomain: [0, 5],
+      yDomain: [0, 5],
+    });
+    expect(
+      store.getState().interactions.has(InteractionChannel.PRIMARY_HOVER),
+    ).toBe(false);
+  });
+
+  it("refreshes a bar at its visible center before removing it outside the domain", () => {
+    const store = createChartStore({ ...config, type: "bar" }, "x", "y");
+    const data = [{ x: "A", y: 15 }];
+    const dimensions = store.getState().dimensions;
+    updateChartState(store, { data, dimensions });
+    registerSeries(store, "bars", [
+      { id: "bars", type: "bar", x: "x", y: "y", barWidth: 20 },
+    ]);
+    upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+      targets: [
+        {
+          data: data[0],
+          dataIndex: 0,
+          seriesId: "bars",
+          coordinate: { x: 0, y: 0 },
+        },
+      ],
+    });
+    updateChartState(store, { data, dimensions, yDomain: [5, 10] });
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toMatchObject({ target: { coordinate: { x: 70, y: 60 } } });
+    updateChartState(store, { data, dimensions, yDomain: [20, 30] });
+    expect(
+      store.getState().interactions.has(InteractionChannel.PRIMARY_HOVER),
+    ).toBe(false);
+  });
+});
+
+describe("hover refresh on plot resizing", () => {
+  const setup = (width = 100) => {
+    const store = createChartStore(
+      { width, height: 100, margin: { left: 0, right: 0, top: 0, bottom: 0 } },
+      "x",
+      "y",
+    );
+    const data = [{ x: 8, y: 5 }];
+    updateChartState(store, {
+      data,
+      dimensions: store.getState().dimensions,
+      xDomain: [0, 10],
+      yDomain: [0, 10],
+    });
+    upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+      targets: [
+        { data: data[0], dataIndex: 0, coordinate: { x: width * 0.8, y: 50 } },
+      ],
+    });
+    return { store, data };
+  };
+
+  it("retains a visible point using expanded dimensions during a domain change", () => {
+    const { store, data } = setup();
+    updateChartState(store, {
+      data,
+      dimensions: { ...store.getState().dimensions, width: 200 },
+      xDomain: [0, 8],
+      yDomain: [0, 10],
+    });
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toMatchObject({ target: { coordinate: { x: 200, y: 50 } } });
+  });
+
+  it("removes a point outside the smaller plot during a domain change", () => {
+    const { store, data } = setup(200);
+    updateChartState(store, {
+      data,
+      dimensions: { ...store.getState().dimensions, width: 100 },
+      xDomain: [0, 5],
+      yDomain: [0, 10],
+    });
+    expect(
+      store.getState().interactions.has(InteractionChannel.PRIMARY_HOVER),
+    ).toBe(false);
+  });
+
+  it("reprojects active hover when dimensions change and clears it for an unavailable plot", () => {
+    const { store } = setup();
+    updateChartDimensions(store, 200, 200);
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toMatchObject({ target: { coordinate: { x: 160, y: 100 } } });
+    updateChartDimensions(store, 0, 0);
+    expect(
+      store.getState().interactions.has(InteractionChannel.PRIMARY_HOVER),
+    ).toBe(false);
+  });
+
+  it("reprojects hover with the new margins and inner dimensions", () => {
+    const { store } = setup();
+    updateChartMargin(store, { left: 20, right: 10, top: 10, bottom: 10 });
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toMatchObject({ target: { coordinate: { x: 76, y: 50 } } });
+  });
+});
+
+describe("KeyboardSensor category lookup cost", () => {
+  it("keeps accessor work linear while constructing visible multi-series slices", () => {
+    const count = 200;
+    let categoryReads = 0;
+    const xAccessor = (datum: { x: number }) => {
+      categoryReads++;
+      return datum.x;
+    };
+    const data = Array.from({ length: count }, (_, x) => ({ x, y: 5 }));
+    const ctx = createMockContext({
+      scales: {
+        x: d3.scaleLinear().domain([0, count]).range([0, 100]),
+        y: d3.scaleLinear().domain([0, 10]).range([100, 0]),
+      },
+      processedSeries: [
+        { id: "first", type: "line", xAccessor, yAccessor: "y", data },
+        { id: "second", type: "line", xAccessor, yAccessor: "y", data },
+      ],
+    });
+    KeyboardSensor()(createMockEvent(InputAction.KEY, "ArrowRight"), ctx);
+    expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toMatchObject({
+      targets: [
+        { seriesId: "first", dataIndex: 0 },
+        { seriesId: "second", dataIndex: 0 },
+      ],
+    });
+    expect(categoryReads).toBeLessThan(count * 20);
+  });
+});
+
+describe("legacy keyboard and hover without domain overrides", () => {
+  it.each(
+    ([undefined, [null, null], [NaN, Infinity]] as const).map((yDomain) => ({
+      yDomain,
+    })),
+  )(
+    "retains an own-series point above the automatic root domain with $yDomain",
+    ({ yDomain }) => {
+      const store = createChartStore(
+        {
+          width: 100,
+          height: 100,
+          margin: { left: 0, right: 0, top: 0, bottom: 0 },
+        },
+        "x",
+        "y",
+      );
+      const data = [
+        { x: "A", y: 10 },
+        { x: "B", y: 20 },
+      ];
+      updateChartState(store, {
+        data,
+        dimensions: store.getState().dimensions,
+        yDomain,
+      });
+      expect(store.getState().scales.y!.domain()).toEqual([0, 22]);
+      registerSeries(store, "own", [
+        {
+          id: "own",
+          type: "line",
+          x: "x",
+          y: "y",
+          data: [
+            { x: "A", y: 23 },
+            { x: "B", y: 20 },
+          ],
+        },
+      ]);
+      const ctx = createMockContext(store.getState());
+      KeyboardSensor()(createMockEvent(InputAction.KEY, "ArrowRight"), ctx);
+      const hover = ctx.getInteraction(InteractionChannel.PRIMARY_HOVER);
+      expect(hover).toMatchObject({
+        target: { data: { x: "A", y: 23 }, dataIndex: 0 },
+      });
+      upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, hover);
+      updateChartState(store, {
+        data,
+        dimensions: store.getState().dimensions,
+        yDomain,
+      });
+      expect(
+        store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+      ).toMatchObject({ target: { data: { x: "A", y: 23 }, dataIndex: 0 } });
+    },
+  );
 });

--- a/components/Chart/sensors/KeyboardSensor/KeyboardSensor.ts
+++ b/components/Chart/sensors/KeyboardSensor/KeyboardSensor.ts
@@ -3,6 +3,8 @@ import { resolveAccessor } from "../../types/accessors";
 import { Sensor } from "../../types/events";
 import { InteractionChannel } from "../../types/interaction";
 import { barGeometry, categoryAccessor } from "../../utils/bars";
+import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import { hasDomainOverride } from "../../utils/scales";
 
 /**
  * Professional-grade Keyboard Sensor for A11y.
@@ -51,115 +53,144 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
         }
       });
     }
-    const data = entries.map((entry) => entry.datum);
-
-    if (!data || data.length === 0 || !scales.x) {
-      return;
-    }
-
-    // Update Focus
-    let changed = false;
-    if (signal.key === "ArrowRight" || signal.key === "ArrowDown") {
-      focusedIndex = Math.min(focusedIndex + 1, data.length - 1);
-      changed = true;
-    } else if (signal.key === "ArrowLeft" || signal.key === "ArrowUp") {
-      focusedIndex = Math.min(Math.max(focusedIndex - 1, 0), data.length - 1);
-      changed = true;
-      if (focusedIndex < 0) {
-        focusedIndex = 0;
-      }
-    } else if (signal.key === "Escape") {
+    if (signal.key === "Escape") {
       focusedIndex = -1;
       removeInteraction(name);
       return;
     }
-
-    if (changed && focusedIndex >= 0) {
-      const d = data[focusedIndex];
-      const { x: xScale, y: yScale } = scales;
-
-      // createChartStore takes the accessors as separate params, so they live
-      // on the store root rather than on `config`.
-      const xAcc = xAccessor ?? ((v: any) => v[0]);
-      const yAcc = yAccessor ?? ((v: any) => v[1]);
-
-      const getX = resolveAccessor(xAcc);
-      const getY = resolveAccessor(yAcc);
-
-      const xVal = getX(d);
-      const yVal = getY(d);
-
-      const xPos = (xScale as any)(xVal) || 0;
-      const yPos = (yScale as any)(yVal) || 0;
-
-      const primaryTarget = {
-        type: "data-point",
-        data: d,
-        seriesId: "default",
-        dataIndex: focusedIndex,
-        coordinate: { x: xPos, y: yPos },
-        distance: 0,
-      };
-
-      const entry = entries[focusedIndex];
-      const category = entry.series && categoryAccessor(entry.series);
-      const categoryValue = category ? resolveAccessor(category)(d) : undefined;
-      const targets = (state.processedSeries ?? []).flatMap((series) => {
-        const accessor = categoryAccessor(series);
-        const index =
-          series.id === entry.series?.id
-            ? entry.index
-            : accessor
-              ? (series.data ?? []).findIndex(
-                  (row) => resolveAccessor(accessor)(row) === categoryValue,
-                )
-              : -1;
-        if (index < 0 || !xScale || !yScale) {
-          return [];
-        }
-        const datum = series.data![index];
-        const bar =
-          series.type === "bar"
-            ? barGeometry(series, datum, index, xScale, yScale)
-            : null;
-        const x = bar
-          ? bar.x + bar.width / 2
-          : (xScale as (v: unknown) => number)(
-              series.xAccessor
-                ? resolveAccessor(series.xAccessor)(datum)
-                : index,
-            );
-        const y = bar
-          ? bar.y + bar.height / 2
-          : (yScale as (v: unknown) => number)(
-              series.yAccessor
-                ? resolveAccessor(series.yAccessor)(datum)
-                : datum,
-            );
-        return [
-          {
-            ...primaryTarget,
-            data: datum,
-            dataIndex: index,
-            seriesId: series.id,
-            seriesColor: series.color,
-            coordinate: { x, y },
-            suppressMarker: series.type === "bar",
-          },
-        ];
-      });
-      const target = targets[0] ?? primaryTarget;
-      upsertInteraction(name, {
-        pointer: {
-          x: target.coordinate.x,
-          y: target.coordinate.y,
-          containerX: target.coordinate.x + state.dimensions.margin.left,
-          containerY: target.coordinate.y + state.dimensions.margin.top,
-          isTouch: false,
-        },
-        targets: targets.length ? targets : [primaryTarget],
-        target,
-      });
+    const forward = signal.key === "ArrowRight" || signal.key === "ArrowDown";
+    const backward = signal.key === "ArrowLeft" || signal.key === "ArrowUp";
+    if (!forward && !backward) {
+      return;
     }
+    const { x: xScale, y: yScale } = scales;
+    if (!xScale || !yScale) {
+      return;
+    }
+    const bounded =
+      hasDomainOverride(xScale, state.xDomain) ||
+      hasDomainOverride(yScale, state.yDomain);
+
+    // Index each series once instead of rescanning its rows for every slice.
+    const categoryIndices = new Map(
+      (state.processedSeries ?? []).map((series) => {
+        const indices = new Map<unknown, number>();
+        const accessor = categoryAccessor(series);
+        if (accessor) {
+          const getCategory = resolveAccessor(accessor);
+          (series.data ?? []).forEach((datum, index) => {
+            const value = getCategory(datum);
+            // Match findIndex's first occurrence and strict equality for NaN.
+            if (!Number.isNaN(value) && !indices.has(value)) {
+              indices.set(value, index);
+            }
+          });
+        }
+        return [series.id, indices];
+      }),
+    );
+
+    // Filter whole slices, preserving a category when any series is visible.
+    const slices = entries
+      .map((entry) => {
+        const d = entry.datum;
+        const primaryTarget = {
+          type: "data-point",
+          data: d,
+          seriesId: "default",
+          dataIndex: entry.index,
+          coordinate: {
+            x: (xScale as (v: unknown) => number)(
+              xAccessor ? resolveAccessor(xAccessor)(d) : d[0],
+            ),
+            y: (yScale as (v: unknown) => number)(
+              yAccessor ? resolveAccessor(yAccessor)(d) : d[1],
+            ),
+          },
+          distance: 0,
+        };
+        const category = entry.series && categoryAccessor(entry.series);
+        const categoryValue = category
+          ? resolveAccessor(category)(d)
+          : undefined;
+        const targets = (state.processedSeries ?? []).flatMap((series) => {
+          const index =
+            series.id === entry.series?.id
+              ? entry.index
+              : (categoryIndices.get(series.id)?.get(categoryValue) ?? -1);
+          if (index < 0 || !xScale || !yScale) {
+            return [];
+          }
+          const datum = series.data![index];
+          const geometry =
+            series.type === "bar"
+              ? barGeometry(series, datum, index, xScale, yScale)
+              : null;
+          const bar =
+            geometry && bounded
+              ? clipRectToPlot(geometry, state.dimensions)
+              : geometry;
+          if (series.type === "bar" && !bar) {
+            return [];
+          }
+          const x = bar
+            ? bar.x + bar.width / 2
+            : (xScale as (v: unknown) => number)(
+                series.xAccessor
+                  ? resolveAccessor(series.xAccessor)(datum)
+                  : index,
+              );
+          const y = bar
+            ? bar.y + bar.height / 2
+            : (yScale as (v: unknown) => number)(
+                series.yAccessor
+                  ? resolveAccessor(series.yAccessor)(datum)
+                  : datum,
+              );
+          if (bounded && !isPointInPlot({ x, y }, state.dimensions)) {
+            return [];
+          }
+          return [
+            {
+              ...primaryTarget,
+              data: datum,
+              dataIndex: index,
+              seriesId: series.id,
+              seriesColor: series.color,
+              coordinate: { x, y },
+              suppressMarker: series.type === "bar",
+            },
+          ];
+        });
+        return targets.length || entry.series
+          ? targets
+          : !bounded ||
+              isPointInPlot(primaryTarget.coordinate, state.dimensions)
+            ? [primaryTarget]
+            : [];
+      })
+      .filter((targets) => targets.length > 0);
+
+    if (!slices.length) {
+      focusedIndex = -1;
+      removeInteraction(name);
+      return;
+    }
+    focusedIndex = forward
+      ? Math.min(focusedIndex + 1, slices.length - 1)
+      : Math.min(Math.max(focusedIndex - 1, 0), slices.length - 1);
+    const targets = slices[focusedIndex];
+    const target = targets[0];
+    upsertInteraction(name, {
+      pointer: {
+        x: target.coordinate.x,
+        y: target.coordinate.y,
+        containerX: target.coordinate.x + state.dimensions.margin.left,
+        containerY: target.coordinate.y + state.dimensions.margin.top,
+        isTouch: false,
+      },
+      targets,
+      target,
+    });
   };
 };

--- a/components/Chart/state/store/chart.store.ts
+++ b/components/Chart/state/store/chart.store.ts
@@ -1,9 +1,14 @@
-import { Accessor, Config } from "../../types";
+import { Accessor, AxisDomain, Config } from "../../types";
 import { InteractionChannel } from "../../types/interaction";
 import { resolveAccessor } from "../../utils/accessors";
 import { barGeometry, categoryAccessor, stackSeries } from "../../utils/bars";
 import { d3 } from "../../utils/d3";
-import { createScales } from "../../utils/scales";
+import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import {
+  createScales,
+  hasDomainOverride,
+  resolveDomain,
+} from "../../utils/scales";
 import { createStore, StoreApi } from "./createStore";
 import { DataSlice, getDataInitialState } from "./slices/data.slice";
 import {
@@ -41,7 +46,10 @@ export interface State<T = any>
     DataSlice<T>,
     SeriesSlice,
     InteractionsSlice,
-    ScalesSlice {}
+    ScalesSlice {
+  xDomain?: AxisDomain;
+  yDomain?: AxisDomain;
+}
 
 /**
  * The Store type for the Chart system.
@@ -106,6 +114,12 @@ export const updateChartDimensions = (
       status: width > 0 && height > 0 ? "ready" : "idle",
       dimensions: nextDimensions,
       scales: nextScales,
+      interactions: refreshHover(
+        { ...prev, dimensions: nextDimensions },
+        prev.data,
+        prev.processedSeries,
+        nextScales,
+      ),
     };
   });
 };
@@ -140,10 +154,16 @@ export const updateChartData = <T>(store: Store, data: T[]) => {
  */
 export const updateChartState = <T>(
   store: Store,
-  props: { data: T[]; type?: string; dimensions: Dimensions },
+  props: {
+    data: T[];
+    type?: string;
+    dimensions: Dimensions;
+    xDomain?: AxisDomain;
+    yDomain?: AxisDomain;
+  },
 ) => {
   store.setState((prev) => {
-    const { data, type, dimensions } = props;
+    const { data, type, dimensions, xDomain, yDomain } = props;
     const { margin } = dimensions;
 
     // Recalculate inner dimensions based on new outer dimensions
@@ -164,10 +184,12 @@ export const updateChartState = <T>(
       ...prev,
       ...derived,
       type: (type || prev.type) as State["type"],
+      xDomain,
+      yDomain,
     });
 
     const nextInteractions = refreshHover(
-      prev,
+      { ...prev, dimensions: nextDimensions, xDomain, yDomain },
       data,
       derived.processedSeries,
       nextScales,
@@ -176,6 +198,8 @@ export const updateChartState = <T>(
     return {
       data,
       type: type || prev.type,
+      xDomain,
+      yDomain,
       dimensions: nextDimensions,
       scales: nextScales,
       ...derived,
@@ -210,9 +234,16 @@ export const updateChartMargin = (
       innerWidth,
       innerHeight,
     };
+    const nextScales = calculateScales(prev.data, nextDimensions, prev);
     return {
       dimensions: nextDimensions,
-      scales: calculateScales(prev.data, nextDimensions, prev),
+      scales: nextScales,
+      interactions: refreshHover(
+        { ...prev, dimensions: nextDimensions },
+        prev.data,
+        prev.processedSeries,
+        nextScales,
+      ),
     } as Partial<State>;
   });
 };
@@ -363,6 +394,9 @@ const refreshHover = (
   if (!hover?.targets?.length) {
     return state.interactions;
   }
+  const bounded =
+    hasDomainOverride(scales.x, state.xDomain) ||
+    hasDomainOverride(scales.y, state.yDomain);
   const targets = hover.targets.flatMap((target) => {
     const item = series.find((item) => item.id === target.seriesId);
     const wasRegistered = state.processedSeries.some(
@@ -382,22 +416,40 @@ const refreshHover = (
       return [];
     }
     const datum = rows[index];
-    const bar =
+    const geometry =
       item?.type === "bar" && scales.x && scales.y
         ? barGeometry(item, datum, index, scales.x, scales.y)
         : null;
+    const bar =
+      geometry && bounded
+        ? clipRectToPlot(geometry, state.dimensions)
+        : geometry;
+    if (!scales.x || !scales.y || (item?.type === "bar" && !bar)) {
+      return [];
+    }
+    const xAccessor = item ? item.xAccessor : state.x;
+    const yAccessor = item ? item.yAccessor : state.y;
+    const coordinate = bar
+      ? { x: bar.x + bar.width / 2, y: bar.y + bar.height / 2 }
+      : {
+          x: (scales.x as (value: unknown) => number)(
+            xAccessor ? resolveAccessor(xAccessor)(datum) : index,
+          ),
+          y: (scales.y as (value: unknown) => number)(
+            yAccessor ? resolveAccessor(yAccessor)(datum) : datum,
+          ),
+        };
+    if (bounded && !isPointInPlot(coordinate, state.dimensions)) {
+      return [];
+    }
     return [
       {
         ...target,
         data: datum,
-        ...(bar
-          ? {
-              coordinate: {
-                x: bar.x + bar.width / 2 + state.dimensions.margin.left,
-                y: bar.y + bar.height / 2 + state.dimensions.margin.top,
-              },
-            }
-          : {}),
+        coordinate: {
+          x: coordinate.x + state.dimensions.margin.left,
+          y: coordinate.y + state.dimensions.margin.top,
+        },
       },
     ];
   });
@@ -427,6 +479,21 @@ const hydrateConfigs = (state: State, data: unknown[]) => {
 };
 
 const calculateScales = (data: any[], dims: Dimensions, state: State) => {
+  const scales = deriveScales(data, dims, state);
+  if (scales.x && "invert" in scales.x) {
+    scales.x.domain(
+      resolveDomain(scales.x.domain() as number[], state.xDomain),
+    );
+  }
+  if (scales.y && "invert" in scales.y) {
+    scales.y.domain(
+      resolveDomain(scales.y.domain() as number[], state.yDomain),
+    );
+  }
+  return scales;
+};
+
+const deriveScales = (data: State["data"], dims: Dimensions, state: State) => {
   const bars = state.processedSeries.filter((series) => series.type === "bar");
   if (bars.length && dims.width > 0 && dims.height > 0) {
     const horizontal = bars[0].orientation === "horizontal";

--- a/components/Chart/subcomponents/Root/Root.tsx
+++ b/components/Chart/subcomponents/Root/Root.tsx
@@ -35,6 +35,8 @@ import {
 import { HoverInteraction } from "../../types/interaction";
 import { barGeometry } from "../../utils/bars";
 import { hasChildOfTypeDeep } from "../../utils/componentDetection";
+import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import { hasDomainOverride } from "../../utils/scales";
 import { Announcer } from "../Announcer";
 import { Axis } from "../Axis/Axis";
 import { CursorWrapper } from "../Cursor/Cursor";
@@ -66,6 +68,8 @@ export type RootProps<T> = Omit<
     Props<T>,
     | "data"
     | "d3Config"
+    | "xDomain"
+    | "yDomain"
     | "className"
     | "style"
     | "onValueChange"
@@ -190,6 +194,8 @@ const accessorSignature = (accessor: unknown, data: any[]): string => {
 export function Root<T>({
   data,
   d3Config,
+  xDomain,
+  yDomain,
   className,
   style,
   onValueChange,
@@ -361,21 +367,38 @@ export function Root<T>({
                 ? resolveAccessor(y)
                 : null;
 
-            const points = seriesData.map((d: any, i: number) => {
-              const bar =
+            const points = seriesData.flatMap((d: any, i: number) => {
+              const geometry =
                 series.type === "bar"
                   ? barGeometry(series, d, i, xScale, yScale)
                   : null;
+              const bounded =
+                hasDomainOverride(xScale, state.xDomain) ||
+                hasDomainOverride(yScale, state.yDomain);
+              const bar =
+                geometry && bounded
+                  ? clipRectToPlot(geometry, dimensions)
+                  : geometry;
+              if (geometry && !bar) {
+                return [];
+              }
+              const position = {
+                x: bar
+                  ? bar.x + bar.width / 2
+                  : (xScale((getX ? getX(d) : i) as any) ?? NaN),
+                y: bar
+                  ? bar.y + bar.height / 2
+                  : (yScale((getY ? getY(d) : d) as any) ?? NaN),
+              };
+              if (bounded && !isPointInPlot(position, dimensions)) {
+                return [];
+              }
               return {
                 x:
-                  (bar
-                    ? bar.x + bar.width / 2
-                    : (xScale((getX ? getX(d) : i) as any) ?? 0)) +
+                  (Number.isFinite(position.x) ? position.x : 0) +
                   dimensions.margin.left,
                 y:
-                  (bar
-                    ? bar.y + bar.height / 2
-                    : (yScale((getY ? getY(d) : d) as any) ?? 0)) +
+                  (Number.isFinite(position.y) ? position.y : 0) +
                   dimensions.margin.top,
                 data: d,
                 seriesId: series.id,
@@ -388,7 +411,9 @@ export function Root<T>({
                     : ("x" as const),
               };
             });
-            allPoints.push(...points);
+            for (const point of points) {
+              allPoints.push(point);
+            }
           });
         } else if (data.length > 0) {
           const getX = x ? resolveAccessor(x) : null;
@@ -406,7 +431,23 @@ export function Root<T>({
             seriesColor: null,
             dataIndex: i,
           }));
-          allPoints.push(...points);
+          for (const point of points) {
+            if (
+              !(
+                hasDomainOverride(xScale, state.xDomain) ||
+                hasDomainOverride(yScale, state.yDomain)
+              ) ||
+              isPointInPlot(
+                {
+                  x: point.x - dimensions.margin.left,
+                  y: point.y - dimensions.margin.top,
+                },
+                dimensions,
+              )
+            ) {
+              allPoints.push(point);
+            }
+          }
         }
 
         engine.updateData(allPoints);
@@ -414,13 +455,17 @@ export function Root<T>({
     });
   }, [chartStore, engine, x, y]);
 
+  const [xMin, xMax] = xDomain ?? [];
+  const [yMin, yMax] = yDomain ?? [];
   useEffect(() => {
     updateChartState(chartStore, {
       data,
       type,
+      xDomain: xMin === undefined ? undefined : [xMin, xMax ?? null],
+      yDomain: yMin === undefined ? undefined : [yMin, yMax ?? null],
       dimensions: chartStore.getState().dimensions,
     });
-  }, [chartStore, data, type]);
+  }, [chartStore, data, type, xMin, xMax, yMin, yMax]);
 
   // The store is built once in a useState initialiser, so a changed x/y prop
   // has to be pushed in. No dependency array: these are usually inline arrows

--- a/components/Chart/subcomponents/Series/Series.tsx
+++ b/components/Chart/subcomponents/Series/Series.tsx
@@ -1,15 +1,56 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useId } from "react";
 
 import { useChartContext } from "../../context";
 import { SeriesProps } from "../../types";
+import { hasDomainOverride } from "../../utils/scales";
 import { BarSeriesWrapper } from "../BarSeries/BarSeries";
 import { CustomSeries } from "../CustomSeries/CustomSeries";
 import { LineSeriesWrapper } from "../LineSeries/LineSeries";
 import { ScatterSeriesWrapper } from "../ScatterSeries/ScatterSeries";
 
 export function Series<T>(props: SeriesProps<T>) {
+  const { chartStore } = useChartContext<T>();
+  const dimensions = chartStore.useStore((state) => state.dimensions);
+  const clipX = chartStore.useStore((state) =>
+    hasDomainOverride(state.scales.x, state.xDomain),
+  );
+  const clipY = chartStore.useStore((state) =>
+    hasDomainOverride(state.scales.y, state.yDomain),
+  );
+  const clipId = useId().replace(/:/g, "");
+  if (props.render) {
+    return <SeriesContent {...props} />;
+  }
+  const { className, style, ...seriesProps } = props;
+  const content = <SeriesContent {...seriesProps} />;
+  return (
+    <g className={className} style={style}>
+      <defs>
+        {(clipX || clipY) && (
+          <clipPath id={clipId}>
+            <rect
+              height={Math.max(
+                0,
+                clipY ? dimensions.innerHeight : dimensions.height,
+              )}
+              width={Math.max(
+                0,
+                clipX ? dimensions.innerWidth : dimensions.width,
+              )}
+              x={clipX ? 0 : -dimensions.margin.left}
+              y={clipY ? 0 : -dimensions.margin.top}
+            />
+          </clipPath>
+        )}
+      </defs>
+      <g clipPath={clipX || clipY ? `url(#${clipId})` : undefined}>{content}</g>
+    </g>
+  );
+}
+
+function SeriesContent<T>(props: SeriesProps<T>) {
   const context = useChartContext<T>();
 
   // Determine type: prop > context > default "line"

--- a/components/Chart/subcomponents/Tooltip/Tooltip.tsx
+++ b/components/Chart/subcomponents/Tooltip/Tooltip.tsx
@@ -9,12 +9,14 @@ import { TooltipOptions } from "../../behaviors/Tooltip";
 import { useChartContext } from "../../context";
 import { resolveAccessor, Series } from "../../types";
 import { HoverInteraction, InteractionChannel } from "../../types/interaction";
-import { categoryAccessor, valueAccessor } from "../../utils/bars";
+import { barGeometry, categoryAccessor, valueAccessor } from "../../utils/bars";
+import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
 import {
   Reposition,
   TOOLTIP_GAP_X,
   TOOLTIP_GAP_Y,
 } from "../../utils/Reposition";
+import { hasDomainOverride } from "../../utils/scales";
 import styles from "./Tooltip.module.scss";
 import { TooltipProps } from "./types";
 
@@ -129,6 +131,14 @@ function DefaultTooltipContent<T>({
   config,
   variant,
 }: DefaultTooltipContentProps<T>) {
+  const { chartStore } = useChartContext<T>();
+  const scales = chartStore.useStore((state) => state.scales);
+  const dimensions = chartStore.useStore((state) => state.dimensions);
+  const bounded = chartStore.useStore(
+    (state) =>
+      hasDomainOverride(state.scales.x, state.xDomain) ||
+      hasDomainOverride(state.scales.y, state.yDomain),
+  );
   const activeSeries = series.find((item) => item.id === activeSeriesId);
   const category = activeSeries ? categoryAccessor(activeSeries) : x;
   const categoryValue = category
@@ -170,6 +180,38 @@ function DefaultTooltipContent<T>({
                     : activeData;
             if (datum === undefined) {
               return null;
+            }
+            if (bounded && scales.x && scales.y) {
+              const bar =
+                item.type === "bar"
+                  ? barGeometry(
+                      item,
+                      datum,
+                      item.data?.indexOf(datum) ?? -1,
+                      scales.x,
+                      scales.y,
+                    )
+                  : null;
+              const visible = bar
+                ? !!clipRectToPlot(bar, dimensions)
+                : isPointInPlot(
+                    {
+                      x: (scales.x as (value: unknown) => number)(
+                        item.xAccessor
+                          ? resolveAccessor(item.xAccessor)(datum)
+                          : undefined,
+                      ),
+                      y: (scales.y as (value: unknown) => number)(
+                        item.yAccessor
+                          ? resolveAccessor(item.yAccessor)(datum)
+                          : undefined,
+                      ),
+                    },
+                    dimensions,
+                  );
+              if (!visible) {
+                return null;
+              }
             }
             return (
               <TooltipSeriesItem

--- a/components/Chart/types/props.ts
+++ b/components/Chart/types/props.ts
@@ -6,12 +6,17 @@ import { Config } from "./config";
 import { RenderFrame } from "./context";
 import { Behavior, Sensor } from "./events";
 
+/** Numeric data bounds; null derives that end automatically. */
+export type AxisDomain = readonly [number | null, number | null];
+
 export interface ChartProps<T = unknown> extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "title" | "children"
 > {
   data: T[];
   d3Config?: Config;
+  xDomain?: AxisDomain;
+  yDomain?: AxisDomain;
   className?: string;
   style?: React.CSSProperties;
   onValueChange?: (data: T | null) => void;

--- a/components/Chart/utils/domains.test.ts
+++ b/components/Chart/utils/domains.test.ts
@@ -1,0 +1,114 @@
+import { expect, it } from "vitest";
+
+import {
+  createChartStore,
+  registerSeries,
+  updateChartData,
+  updateChartState,
+} from "../state/store/chart.store";
+import { createScales } from "./scales";
+
+const dimensions = { top: 0, right: 0, bottom: 0, left: 0 };
+for (const values of [
+  [-20, 10, 35],
+  [-30, -10],
+  [0, 0],
+  [-5, -5],
+  [5, 5],
+  [],
+]) {
+  it(`keeps automatic Y domain finite, ascending, and containing ${JSON.stringify(values)}`, () => {
+    const { yScale } = createScales(
+      values,
+      400,
+      300,
+      dimensions,
+      (v) => v,
+      (v) => v,
+    );
+    const [min, max] = yScale.domain();
+    expect(Number.isFinite(min) && Number.isFinite(max)).toBe(true);
+    expect(min).toBeLessThan(max);
+    for (const value of values) {
+      expect(yScale(value)).toBeGreaterThanOrEqual(0);
+      expect(yScale(value)).toBeLessThanOrEqual(300);
+    }
+  });
+}
+function setup(
+  xDomain?: readonly [number | null, number | null],
+  yDomain?: readonly [number | null, number | null],
+) {
+  const store = createChartStore({ width: 400, height: 300 }, "x", "y");
+  updateChartState(store, {
+    data: [
+      { x: 0, y: -20 },
+      { x: 10, y: 35 },
+    ],
+    dimensions: store.getState().dimensions,
+    xDomain,
+    yDomain,
+  });
+  return store;
+}
+it("preserves exact numeric overrides through data and dimension updates", () => {
+  const store = setup([-2, 12], [-50, 101]);
+  expect(store.getState().scales.x!.domain()).toEqual([-2, 12]);
+  expect(store.getState().scales.y!.domain()).toEqual([-50, 101]);
+  updateChartData(store, [{ x: 100, y: 200 }]);
+  expect(store.getState().scales.y!.domain()).toEqual([-50, 101]);
+});
+it("supports automatic ends even when the fixed end excludes all data", () => {
+  const store = setup([20, null], [null, -100]);
+  const x = store.getState().scales.x!.domain() as number[];
+  const y = store.getState().scales.y!.domain() as number[];
+  expect(x[0]).toBe(20);
+  expect(x[1]).toBeGreaterThan(20);
+  expect(y[1]).toBe(-100);
+  expect(y[0]).toBeLessThan(-100);
+});
+for (const bounds of [
+  [NaN, 10],
+  [0, Infinity],
+  [20, -20],
+  [5, 5],
+] as const) {
+  it(`falls back to automatic for invalid bounds ${bounds}`, () => {
+    expect(setup(undefined, bounds).getState().scales.y!.domain()).toEqual(
+      setup().getState().scales.y!.domain(),
+    );
+  });
+}
+it("applies overrides after stack totals and leaves category domains intact", () => {
+  const store = createChartStore(
+    { width: 400, height: 300, type: "bar" },
+    "value",
+    "category",
+  );
+  updateChartState(store, {
+    data: [{ category: "A", value: 10 }],
+    dimensions: store.getState().dimensions,
+    xDomain: [-5, 15],
+    yDomain: [0, 100],
+  });
+  registerSeries(store, "a", [
+    {
+      type: "bar",
+      orientation: "horizontal",
+      x: "value",
+      y: "category",
+      stackId: "s",
+    },
+  ]);
+  expect(store.getState().scales.x!.domain()).toEqual([-5, 15]);
+  expect(store.getState().scales.y!.domain()).toEqual(["A"]);
+});
+it("removes overrides on a prop update", () => {
+  const store = setup(undefined, [-50, 100]);
+  updateChartState(store, {
+    data: [{ x: 0, y: 10 }],
+    dimensions: store.getState().dimensions,
+    yDomain: undefined,
+  });
+  expect(store.getState().scales.y!.domain()[0]).toBe(0);
+});

--- a/components/Chart/utils/plotBounds.test.ts
+++ b/components/Chart/utils/plotBounds.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { clipRectToPlot, isPointInPlot } from "./plotBounds";
+
+const bounds = { innerWidth: 100, innerHeight: 80 };
+
+describe("plot bounds", () => {
+  it("includes point centers on plot edges and excludes outside or nonfinite centers", () => {
+    expect(isPointInPlot({ x: 0, y: 80 }, bounds)).toBe(true);
+    expect(isPointInPlot({ x: 100, y: 0 }, bounds)).toBe(true);
+    for (const point of [
+      { x: -1, y: 40 },
+      { x: 101, y: 40 },
+      { x: 50, y: -1 },
+      { x: 50, y: 81 },
+      { x: NaN, y: 40 },
+      { x: 50, y: Infinity },
+    ]) {
+      expect(isPointInPlot(point, bounds)).toBe(false);
+    }
+  });
+
+  it("intersects rectangles at each plot edge", () => {
+    expect(
+      clipRectToPlot({ x: -20, y: -10, width: 150, height: 110 }, bounds),
+    ).toEqual({ x: 0, y: 0, width: 100, height: 80 });
+    expect(
+      clipRectToPlot({ x: 90, y: 70, width: 20, height: 30 }, bounds),
+    ).toEqual({ x: 90, y: 70, width: 10, height: 10 });
+  });
+
+  it("omits fully outside bars and bars that merely touch an outer edge", () => {
+    for (const rect of [
+      { x: -20, y: 10, width: 20, height: 10 },
+      { x: 100, y: 10, width: 20, height: 10 },
+      { x: 20, y: -20, width: 10, height: 20 },
+      { x: 20, y: 80, width: 10, height: 20 },
+    ]) {
+      expect(clipRectToPlot(rect, bounds)).toBeNull();
+    }
+  });
+
+  it("retains zero-value bars inside the plot", () => {
+    expect(
+      clipRectToPlot({ x: 20, y: 80, width: 10, height: 0 }, bounds),
+    ).toEqual({ x: 20, y: 80, width: 10, height: 0 });
+  });
+
+  it("rejects invalid geometry and unavailable plot bounds", () => {
+    expect(
+      clipRectToPlot({ x: NaN, y: 10, width: 10, height: 10 }, bounds),
+    ).toBeNull();
+    expect(
+      clipRectToPlot({ x: 10, y: 10, width: -1, height: 10 }, bounds),
+    ).toBeNull();
+    expect(
+      clipRectToPlot(
+        { x: 10, y: 10, width: 10, height: 10 },
+        { innerWidth: NaN, innerHeight: 80 },
+      ),
+    ).toBeNull();
+    expect(
+      isPointInPlot(
+        { x: 10, y: 10 },
+        { innerWidth: Infinity, innerHeight: 80 },
+      ),
+    ).toBe(false);
+  });
+});

--- a/components/Chart/utils/plotBounds.ts
+++ b/components/Chart/utils/plotBounds.ts
@@ -1,0 +1,59 @@
+/** Plot-local bounds shared by spatial indexing and interaction sensors. */
+export interface PlotBounds {
+  innerWidth: number;
+  innerHeight: number;
+}
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+interface Rect extends Point {
+  width: number;
+  height: number;
+}
+
+export function isPointInPlot(point: Point, bounds: PlotBounds): boolean {
+  return (
+    Number.isFinite(bounds.innerWidth) &&
+    Number.isFinite(bounds.innerHeight) &&
+    Number.isFinite(point.x) &&
+    Number.isFinite(point.y) &&
+    point.x >= 0 &&
+    point.y >= 0 &&
+    point.x <= bounds.innerWidth &&
+    point.y <= bounds.innerHeight
+  );
+}
+
+/** Retains zero-size bars inside the plot so zero values remain navigable. */
+export function clipRectToPlot(rect: Rect, bounds: PlotBounds): Rect | null {
+  if (
+    ![
+      rect.x,
+      rect.y,
+      rect.width,
+      rect.height,
+      bounds.innerWidth,
+      bounds.innerHeight,
+    ].every(Number.isFinite) ||
+    rect.width < 0 ||
+    rect.height < 0
+  ) {
+    return null;
+  }
+  const x = Math.max(0, rect.x);
+  const y = Math.max(0, rect.y);
+  const right = Math.min(bounds.innerWidth, rect.x + rect.width);
+  const bottom = Math.min(bounds.innerHeight, rect.y + rect.height);
+  if (
+    right < x ||
+    bottom < y ||
+    (right === x && rect.width > 0) ||
+    (bottom === y && rect.height > 0)
+  ) {
+    return null;
+  }
+  return { x, y, width: right - x, height: bottom - y };
+}

--- a/components/Chart/utils/scales.ts
+++ b/components/Chart/utils/scales.ts
@@ -1,5 +1,7 @@
 import { ScaleBand, ScaleLinear, ScalePoint, ScaleTime } from "d3-scale";
 
+import { AxisDomain } from "../types/props";
+import { Scale } from "../types/scales";
 import { d3 } from "./d3";
 
 export type ChartXScale =
@@ -39,7 +41,7 @@ export function createScales<T>(
   if (typeof firstValue === "number") {
     xScale = d3
       .scaleLinear()
-      .domain(d3.extent(xValues as number[]) as [number, number])
+      .domain(numericExtent(xValues as number[]))
       .range([0, innerWidth]);
   } else {
     const uniqueXValues = Array.from(new Set(xValues as string[]));
@@ -63,7 +65,7 @@ export function createScales<T>(
   const yValues = data.map(y);
   const yScale = d3
     .scaleLinear()
-    .domain([0, (d3.max(yValues) || 0) * 1.1])
+    .domain(automaticYDomain(yValues))
     .nice()
     .range([innerHeight, 0]);
 
@@ -72,3 +74,57 @@ export function createScales<T>(
 
 /** Tick budget shared by the Y axis and the grid, so the two cannot drift. */
 export const yTickCount = (isMobile?: boolean) => (isMobile ? 3 : 5);
+
+export function automaticYDomain(values: number[]): [number, number] {
+  const finite = values.filter(Number.isFinite);
+  const min = Math.min(0, d3.min(finite) ?? 0);
+  const max = Math.max(0, d3.max(finite) ?? 0);
+  return [min * 1.1, max * 1.1 || (min < 0 ? 0 : 1)];
+}
+
+function numericExtent(values: number[]): [number, number] {
+  const finite = values.filter(Number.isFinite);
+  const min = d3.min(finite) ?? 0;
+  const max = d3.max(finite) ?? 1;
+  return min === max ? [min - 1, max + 1] : [min, max];
+}
+
+export function resolveDomain(
+  automatic: number[],
+  bounds?: AxisDomain,
+): number[] {
+  if (
+    !bounds ||
+    bounds.some((value) => value !== null && !Number.isFinite(value))
+  ) {
+    return automatic;
+  }
+  const [lower, upper] = bounds;
+  if (lower !== null && upper !== null && lower >= upper) {
+    return automatic;
+  }
+  let min = lower ?? automatic[0];
+  let max = upper ?? automatic[1];
+  if (min >= max) {
+    if (lower !== null) {
+      max = min + Math.max(1, Math.abs(min) * 0.1);
+    } else {
+      min = max - Math.max(1, Math.abs(max) * 0.1);
+    }
+  }
+  return [min, max];
+}
+
+export function hasDomainOverride(
+  scale: Scale | null,
+  bounds?: AxisDomain,
+): boolean {
+  return (
+    !!scale &&
+    "invert" in scale &&
+    !!bounds &&
+    bounds.some((value) => value !== null) &&
+    bounds.every((value) => value === null || Number.isFinite(value)) &&
+    (bounds[0] === null || bounds[1] === null || bounds[0] < bounds[1])
+  );
+}

--- a/skills/doom-design-system/components/chart.md
+++ b/skills/doom-design-system/components/chart.md
@@ -20,6 +20,8 @@ component's own semantics win on conflict.
 | `data` | `T[]` | required | Data array |
 | `x` | `keyof T \| (d: T) => string \| number` | required | X-axis accessor (string key or function) |
 | `y` | `keyof T \| (d: T) => number` | required | Y-axis accessor (string key or function) |
+| `xDomain` | `readonly [number \| null, number \| null]` | automatic | Numeric X bounds; `null` keeps that end automatic. Ignored for categorical X. |
+| `yDomain` | `readonly [number \| null, number \| null]` | automatic | Numeric Y bounds; `null` keeps that end automatic. Ignored for categorical Y. |
 | `type` | `"line" \| "area" \| "bar" \| "scatter"` | — | Chart type (shorthand API) |
 | `title` | `string \| ReactNode` | — | Chart title |
 | `subtitle` | `string` | — | Chart subtitle |
@@ -92,6 +94,66 @@ component's own semantics win on conflict.
   }}
 />
 ```
+
+## Axis domains
+
+`xDomain` and `yDomain` are top-level props on both `Chart` and `Chart.Root`,
+not fields in `d3Config`. Each accepts a readonly `[lower, upper]` tuple.
+An omitted prop or `[null, null]` uses automatic bounds. Each numeric endpoint
+is exact: padding and D3 `nice()` do not move an explicit endpoint. A `null`
+endpoint retains the corresponding automatic bound.
+
+```tsx
+// Reuse the same bounds and chart height for an honest regional comparison.
+const revenueDomain = [0, 100] as const;
+
+<Chart data={north} type="line" x="month" y="revenue"
+  yDomain={revenueDomain} title="North revenue (USD thousands)" />
+<Chart data={south} type="line" x="month" y="revenue"
+  yDomain={revenueDomain} title="South revenue (USD thousands)" />
+
+// Fix only the upper bound; calculate the lower bound automatically.
+<Chart.Root data={readings} type="line" x="hour" y="temperature"
+  xDomain={[0, 24]} yDomain={[null, 40]}>
+  <Chart.Plot>
+    <Chart.Series label="Temperature (°C)" type="line" />
+    <Chart.Axis />
+  </Chart.Plot>
+</Chart.Root>
+```
+
+- A tuple containing a nonfinite number (`NaN` or either infinity), or two
+  explicit bounds that are reversed or equal, is ignored in its entirety.
+  That axis falls back to its automatic domain.
+- If a one-sided override would leave the domain descending or collapsed,
+  the automatic end extends outward by `max(1, abs(explicitEndpoint) * 0.1)`.
+  For example, automatic `[0, 5]` with `[20, null]` becomes `[20, 22]`.
+  The explicit end stays exact, even when it excludes all data.
+- Categorical axes ignore overrides. For vertical bars, use `yDomain` for
+  values; for horizontal bars, use `xDomain` for values.
+
+Without overrides, numeric Y bounds include zero, pad negative and positive
+extrema outward by 10%, then apply D3 `nice()` for readable ticks. A negative
+line metric can therefore cross zero without losing its negative values.
+The empty-data scale utility starts with `[0, 1]` and applies `nice()`;
+an empty chart currently creates no scales.
+
+For charts containing only non-bar series, automatic bounds come from root
+`data` and accessors. A series' own data does not expand those bounds: give
+the root a dataset spanning all series, or set explicit bounds covering them.
+Bar bounds account for registered series and signed stack totals; mixed
+vertical-bar charts also retain and expand existing root and non-bar domains.
+Overrides apply after these automatic domains are calculated.
+
+With a valid numeric domain override, built-in series rendering is clipped
+along that axis. Marks on unaffected axes retain their normal appearance.
+Points whose centers fall outside the plot are excluded from interactions,
+including hover and keyboard navigation. Partially visible bars remain
+interactable; their tooltip values describe the original data, not just the
+visible portion. Custom rendering is responsible for its own clipping.
+
+See the **Signed Line Metric** and **Shared Fixed Y Bounds** stories for signed
+cash flow and two regions compared with equal heights and the same exact range.
 
 ## Architecture
 
@@ -181,7 +243,8 @@ Each series type registers itself with the store and gets an automatic interacti
 
 A `<Chart.Series>` may carry its own `data`, which is used for both rendering and
 hit-testing. In charts containing only non-bar series, scales derive from root
-`data`; give `Chart.Root` a dataset spanning the full range. Bars derive their
+`data`; give `Chart.Root` a dataset spanning the full range or explicit
+`xDomain` / `yDomain` bounds covering the series. Bars derive their
 category domain and signed value totals from registered series data. Mixed
 vertical-bar charts preserve and expand root and registered non-bar domains.
 See [bar orientation, thickness, and stacks](#bar-orientation-thickness-and-stacks).


### PR DESCRIPTION
## What changes

Line data such as `[-20, 10, 35]` previously used a zero-based Y domain that put negative points outside the plot. Automatic Y domains now include signed data and handle zero/constant values.

Add typed `xDomain` and `yDomain` props to `Chart` and `Chart.Root`. For example, `yDomain={[-50, 100]}` fixes the visible data bounds; `[null, 100]` derives the lower end automatically. Explicit endpoints are not changed by padding or tick rounding. Invalid overrides fall back to automatic bounds; categorical axes ignore them.

Built-in series clip along explicitly bounded axes, and interactions exclude offplot targets when effective overrides apply. Partial bars retain their original tooltip values. Changes to domains, dimensions, or margins refresh active targets; adding/removing bounds preserves series identity. Charts without overrides retain their existing keyboard behavior. Custom renderers remain responsible for their own clipping.

Includes signed cash-flow and shared-range regional comparison stories, plus documentation of bounds precedence and root/series automatic-domain semantics.

## Validation

- Red/green coverage for negative and degenerate domains, exact/one-sided bounds, clipping, tooltip filtering, stable series identity, and keyboard/resize regressions.
- 902 unit tests and 92 Playwright Chromium tests pass.
- Build and package verification pass (including 3 package integration tests).
- Storybook build passes; both new stories visually inspected.
- ESLint: no errors; 463 existing warnings.
- Independent review completed; concrete findings addressed and verified.

Fixes #81.
