### PR TITLE
chore: release 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doom-design-system",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doom-design-system",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doom-design-system",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Neubrutalist and comic book inspired design system",
   "sideEffects": [
     "**/*.css",


### PR DESCRIPTION
Bump the package and lockfile to 0.8.0 for the Chart capabilities and interaction fixes merged since 0.7.0. A clean install and npm pack completed successfully, including build validation, publint, and all three package-import tests. The tarball contains only distribution files and package metadata. npm publication is awaiting renewed login.