### PR TITLE
fix(Chart): respect tooltip targets and add shared axis controls

### DIFF
--- a/components/A2UI/catalog.ts
+++ b/components/A2UI/catalog.ts
@@ -1122,6 +1122,12 @@ export const componentCatalog: ComponentDescriptor[] = [
         required: true,
         description: "Data key for Y axis",
       },
+      {
+        name: "d3Config",
+        type: "object",
+        description:
+          "Chart configuration, including xMaxTicks to limit X labels. xTickFormat is a React callback and cannot be represented in JSON.",
+      },
       { name: "title", type: "string", description: "Chart title" },
       { name: "subtitle", type: "string", description: "Chart subtitle" },
     ],

--- a/components/A2UI/catalog.ts
+++ b/components/A2UI/catalog.ts
@@ -1126,7 +1126,7 @@ export const componentCatalog: ComponentDescriptor[] = [
         name: "d3Config",
         type: "object",
         description:
-          "Chart configuration, including xMaxTicks to limit X labels. xTickFormat is a React callback and cannot be represented in JSON.",
+          "Chart configuration. axes.x.maxTicks and axes.y.maxTicks limit labels independently. Axis tickFormat callbacks are available in React, not JSON.",
       },
       { name: "title", type: "string", description: "Chart title" },
       { name: "subtitle", type: "string", description: "Chart subtitle" },

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -173,152 +173,6 @@ export const SignedLineMetric: Story = {
   ),
 };
 
-const dailySignups = Array.from({ length: 40 }, (_, day) => ({
-  date: Date.UTC(2026, 0, 1 + day),
-  signups: 24 + Math.floor(day / 7) * 5 + [8, 12, 6, 15, 9, 2, 0][day % 7],
-}));
-const signupDateFormat = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  timeZone: "UTC",
-});
-const signupBehaviors = [
-  Chart.behaviors.Tooltip<(typeof dailySignups)[number]>({
-    render: (datum) =>
-      `${signupDateFormat.format(datum.date)}: ${datum.signups} signups`,
-  }),
-  Chart.behaviors.Cursor(),
-  Chart.behaviors.Markers(),
-];
-
-export const DailySignups: Story = {
-  tags: ["interaction"],
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Forty daily observations retain their numeric timestamps and spacing. xTickFormat formats labels in UTC; xMaxTicks caps labels without aggregating or dropping data. Numeric ticks use the existing linear scale, not calendar-aligned time intervals.",
-      },
-    },
-  },
-  render: () => (
-    <Chart
-      behaviors={signupBehaviors}
-      className={storyStyles.domainChart}
-      d3Config={{
-        showDots: true,
-        xAxisLabel: "Date (UTC)",
-        yAxisLabel: "Signups",
-        xTickFormat: (value) => signupDateFormat.format(Number(value)),
-        xMaxTicks: 6,
-      }}
-      data={dailySignups}
-      subtitle="Jan 1 – Feb 9, 2026 · daily totals · UTC"
-      title="Daily signups"
-      type="line"
-      x="date"
-      y="signups"
-    />
-  ),
-  play: async ({ canvasElement, step }) => {
-    await step(
-      "Date labels stay concise while all daily observations remain",
-      async () => {
-        await waitFor(() => {
-          const labels = canvasElement.querySelectorAll(
-            '[aria-label="X Axis"] .tick text',
-          );
-          expect(labels.length).toBeGreaterThan(1);
-          expect(labels.length).toBeLessThanOrEqual(6);
-          for (const label of labels) {
-            expect(label.textContent).toMatch(/^(Jan|Feb) \d{1,2}$/);
-          }
-          expect(
-            canvasElement.querySelectorAll(".chart-line-series circle"),
-          ).toHaveLength(40);
-        });
-      },
-    );
-  },
-};
-
-const revenueAgainstPlan = [
-  { month: "Jan", actual: 42, plan: 45 },
-  { month: "Feb", actual: 47, plan: 50 },
-  { month: "Mar", actual: 61, plan: 55 },
-  { month: "Apr", actual: 54, plan: 60 },
-  { month: "May", actual: 69, plan: 65 },
-];
-const singlePointSensors = [
-  Chart.sensors.DataHoverSensor({ verticalSlice: false }),
-  Chart.sensors.KeyboardSensor(),
-];
-
-export const RevenueAgainstPlan: Story = {
-  tags: ["interaction"],
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Actual revenue and the monthly plan share the same dates. The tooltip describes only the hovered line through Chart.sensors.DataHoverSensor({ verticalSlice: false }); the default cursor and markers remain active. Keyboard navigation is explicitly retained because sensors replaces the defaults.",
-      },
-    },
-  },
-  render: () => (
-    <Chart.Root
-      className={storyStyles.domainChart}
-      d3Config={{ showDots: true, yAxisLabel: "Revenue (USD thousands)" }}
-      data={revenueAgainstPlan}
-      sensors={singlePointSensors}
-      type="line"
-      x="month"
-      y="actual"
-    >
-      <Chart.Header
-        subtitle="USD thousands · hover a line to inspect its value"
-        title="Revenue against plan"
-      >
-        <Chart.Legend layout="horizontal" />
-      </Chart.Header>
-      <Chart.Plot>
-        <Chart.Grid />
-        <Chart.Axis />
-        <Chart.Series label="Actual" type="line" x="month" y="actual" />
-        <Chart.Series label="Plan" type="line" x="month" y="plan" />
-        <Chart.Cursor />
-      </Chart.Plot>
-    </Chart.Root>
-  ),
-  play: async ({ canvasElement, step }) => {
-    await step(
-      "Hovering actual revenue excludes the plan from its tooltip",
-      async () => {
-        await waitFor(() =>
-          expect(
-            canvasElement.querySelectorAll(".chart-line-series circle"),
-          ).toHaveLength(10),
-        );
-        const point = canvasElement.querySelectorAll(
-          ".chart-line-series circle",
-        )[2];
-        const rect = point.getBoundingClientRect();
-        await userEvent.pointer({
-          target: point,
-          coords: {
-            clientX: rect.left + rect.width / 2,
-            clientY: rect.top + rect.height / 2,
-          },
-        });
-        await waitFor(() => {
-          const tooltip = canvasElement.querySelector("[data-chart-tooltip]");
-          expect(tooltip?.textContent).toContain("Actual:61");
-          expect(tooltip?.textContent).not.toContain("Plan");
-        });
-      },
-    );
-  },
-};
-
 const regionalRevenue = [
   {
     region: "North",
@@ -1181,57 +1035,171 @@ export const StringAccessors: Story = {
   },
 };
 
-/**
- * Multi-series charts allow multiple data visualizations on a single chart.
- * Each series can have its own y-accessor, color, and label.
- */
+interface RevenueObservation {
+  date: number;
+  revenue: number;
+  series: "Actual revenue" | "Plan";
+}
+
+const revenueDateFormat = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+const revenueUsdFormat = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+const revenuePlan: RevenueObservation[] = Array.from(
+  { length: 40 },
+  (_, day) => ({
+    date: Date.UTC(2026, 0, 1 + day),
+    revenue: 4000 + day * 100,
+    series: "Plan",
+  }),
+);
+const actualRevenue: RevenueObservation[] = revenuePlan.map((datum, day) => ({
+  ...datum,
+  revenue: datum.revenue + [-600, -200, 900, 400, 1200, -800, -1000][day % 7],
+  series: "Actual revenue",
+}));
+// Root data spans both series so automatic bounds include every observation.
+const dailyRevenue = [...actualRevenue, ...revenuePlan].sort(
+  (a, b) => a.date - b.date,
+);
+const revenueSensors = [
+  Chart.sensors.DataHoverSensor({ verticalSlice: false }),
+  Chart.sensors.KeyboardSensor(),
+];
+const revenueBehaviors = [
+  Chart.behaviors.Tooltip<RevenueObservation | RevenueObservation[]>({
+    render: (reading) => (
+      <Card>
+        <Stack gap={2}>
+          {(Array.isArray(reading) ? reading : [reading]).map((datum) => (
+            <Stack key={datum.series} gap={1}>
+              <Text variant="h6">
+                {revenueDateFormat.format(datum.date)} · UTC
+              </Text>
+              <Text>
+                {datum.series}: {revenueUsdFormat.format(datum.revenue)}
+              </Text>
+            </Stack>
+          ))}
+        </Stack>
+      </Card>
+    ),
+  }),
+  Chart.behaviors.Cursor(),
+  Chart.behaviors.Markers(),
+];
+
 export const MultiSeries: Story = {
-  render: () => {
-    // Generate some intricate data
-    const data = [
-      { month: "Jan", revenue: 15000, users: 1200, expenses: 8000 },
-      { month: "Feb", revenue: 28000, users: 1800, expenses: 12000 },
-      { month: "Mar", revenue: 22000, users: 1500, expenses: 10000 },
-      { month: "Apr", revenue: 35000, users: 2200, expenses: 15000 },
-      { month: "May", revenue: 42000, users: 2800, expenses: 18000 },
-      { month: "Jun", revenue: 38000, users: 2500, expenses: 16000 },
-    ];
-
-    return (
-      <Chart.Root
-        d3Config={{ grid: true, showDots: true }}
-        data={data}
-        style={{ width: "100%", maxWidth: 800, height: 400 }}
-        type="line"
-        x="month"
-        y="revenue"
+  tags: ["interaction"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Compare actual daily revenue with plan in the same USD units over 40 days. d3Config.axes formats numeric UTC timestamps and currency ticks while limiting label density. Each series supplies its own data and tooltip metadata. Single-target pointer hover shows only the selected series; keyboard navigation, cursor, and markers are retained explicitly because custom sensors and behaviors replace the defaults.",
+      },
+    },
+  },
+  render: () => (
+    <Chart.Root
+      behaviors={revenueBehaviors}
+      className={storyStyles.domainChart}
+      d3Config={{
+        grid: true,
+        showDots: true,
+        xAxisLabel: "Date (UTC)",
+        yAxisLabel: "Daily revenue (USD)",
+        axes: {
+          x: {
+            tickFormat: (value) => revenueDateFormat.format(Number(value)),
+            maxTicks: 6,
+          },
+          y: {
+            tickFormat: (value) => revenueUsdFormat.format(Number(value)),
+            maxTicks: 5,
+          },
+        },
+      }}
+      data={dailyRevenue}
+      sensors={revenueSensors}
+      type="line"
+      x="date"
+      y="revenue"
+    >
+      <Chart.Header
+        subtitle="Jan 1 – Feb 9, 2026 · daily totals · hover a line to inspect revenue"
+        title="Daily revenue against plan"
       >
-        <Chart.Header title="Multi-Series Line Chart">
-          <Chart.Legend layout="horizontal" />
-        </Chart.Header>
-
-        {/* With layout="custom", we must explicitly define the plot and its layers */}
-        <Chart.Plot>
-          <Chart.Grid />
-          <Chart.Cursor />
-          <Chart.Series
-            color="var(--primary)"
-            label="Revenue"
-            type="line"
-            x="month"
-            y="revenue"
-          />
-          <Chart.Series
-            color="var(--secondary)"
-            label="Expenses"
-            type="line"
-            x="month"
-            y="expenses"
-          />
-          <Chart.Axis />
-        </Chart.Plot>
-      </Chart.Root>
+        <Chart.Legend layout="horizontal" />
+      </Chart.Header>
+      <Chart.Plot>
+        <Chart.Grid />
+        <Chart.Axis />
+        <Chart.Series data={actualRevenue} label="Actual revenue" type="line" />
+        <Chart.Series data={revenuePlan} label="Plan" type="line" />
+        <Chart.Cursor />
+      </Chart.Plot>
+    </Chart.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      "Daily observations have readable date and currency axes",
+      async () => {
+        await waitFor(() => {
+          const dates = canvasElement.querySelectorAll(
+            '[aria-label="X Axis"] .tick text',
+          );
+          const amounts = canvasElement.querySelectorAll(
+            '[aria-label="Y Axis"] .tick text',
+          );
+          expect(dates.length).toBeGreaterThan(1);
+          expect(dates.length).toBeLessThanOrEqual(6);
+          for (const label of dates) {
+            expect(label.textContent).toMatch(/^(Jan|Feb) \d{1,2}$/);
+          }
+          expect(amounts.length).toBeGreaterThan(1);
+          expect(amounts.length).toBeLessThanOrEqual(5);
+          for (const label of amounts) {
+            expect(label.textContent).toMatch(/^\$[\d,]+$/);
+          }
+          expect(
+            canvasElement.querySelectorAll(".chart-line-series circle"),
+          ).toHaveLength(80);
+        });
+      },
     );
+    await step("Each line reports its own dated revenue reading", async () => {
+      const points = canvasElement.querySelectorAll(
+        ".chart-line-series circle",
+      );
+      for (const [index, expected] of [
+        [2, "Actual revenue: $5,100"],
+        [42, "Plan: $4,200"],
+      ] as const) {
+        const point = points[index];
+        const rect = point.getBoundingClientRect();
+        await userEvent.pointer({
+          target: point,
+          coords: {
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          },
+        });
+        await waitFor(() => {
+          const tooltip = canvasElement.querySelector("[data-chart-tooltip]");
+          expect(tooltip).toHaveTextContent("Jan 3 · UTC");
+          expect(tooltip).toHaveTextContent(expected);
+          expect(tooltip).not.toHaveTextContent(
+            index === 2 ? "Plan:" : "Actual revenue:",
+          );
+        });
+      }
+    });
   },
 };
 

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -173,6 +173,152 @@ export const SignedLineMetric: Story = {
   ),
 };
 
+const dailySignups = Array.from({ length: 40 }, (_, day) => ({
+  date: Date.UTC(2026, 0, 1 + day),
+  signups: 24 + Math.floor(day / 7) * 5 + [8, 12, 6, 15, 9, 2, 0][day % 7],
+}));
+const signupDateFormat = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+const signupBehaviors = [
+  Chart.behaviors.Tooltip<(typeof dailySignups)[number]>({
+    render: (datum) =>
+      `${signupDateFormat.format(datum.date)}: ${datum.signups} signups`,
+  }),
+  Chart.behaviors.Cursor(),
+  Chart.behaviors.Markers(),
+];
+
+export const DailySignups: Story = {
+  tags: ["interaction"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Forty daily observations retain their numeric timestamps and spacing. xTickFormat formats labels in UTC; xMaxTicks caps labels without aggregating or dropping data. Numeric ticks use the existing linear scale, not calendar-aligned time intervals.",
+      },
+    },
+  },
+  render: () => (
+    <Chart
+      behaviors={signupBehaviors}
+      className={storyStyles.domainChart}
+      d3Config={{
+        showDots: true,
+        xAxisLabel: "Date (UTC)",
+        yAxisLabel: "Signups",
+        xTickFormat: (value) => signupDateFormat.format(Number(value)),
+        xMaxTicks: 6,
+      }}
+      data={dailySignups}
+      subtitle="Jan 1 – Feb 9, 2026 · daily totals · UTC"
+      title="Daily signups"
+      type="line"
+      x="date"
+      y="signups"
+    />
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      "Date labels stay concise while all daily observations remain",
+      async () => {
+        await waitFor(() => {
+          const labels = canvasElement.querySelectorAll(
+            '[aria-label="X Axis"] .tick text',
+          );
+          expect(labels.length).toBeGreaterThan(1);
+          expect(labels.length).toBeLessThanOrEqual(6);
+          for (const label of labels) {
+            expect(label.textContent).toMatch(/^(Jan|Feb) \d{1,2}$/);
+          }
+          expect(
+            canvasElement.querySelectorAll(".chart-line-series circle"),
+          ).toHaveLength(40);
+        });
+      },
+    );
+  },
+};
+
+const revenueAgainstPlan = [
+  { month: "Jan", actual: 42, plan: 45 },
+  { month: "Feb", actual: 47, plan: 50 },
+  { month: "Mar", actual: 61, plan: 55 },
+  { month: "Apr", actual: 54, plan: 60 },
+  { month: "May", actual: 69, plan: 65 },
+];
+const singlePointSensors = [
+  Chart.sensors.DataHoverSensor({ verticalSlice: false }),
+  Chart.sensors.KeyboardSensor(),
+];
+
+export const RevenueAgainstPlan: Story = {
+  tags: ["interaction"],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Actual revenue and the monthly plan share the same dates. The tooltip describes only the hovered line through Chart.sensors.DataHoverSensor({ verticalSlice: false }); the default cursor and markers remain active. Keyboard navigation is explicitly retained because sensors replaces the defaults.",
+      },
+    },
+  },
+  render: () => (
+    <Chart.Root
+      className={storyStyles.domainChart}
+      d3Config={{ showDots: true, yAxisLabel: "Revenue (USD thousands)" }}
+      data={revenueAgainstPlan}
+      sensors={singlePointSensors}
+      type="line"
+      x="month"
+      y="actual"
+    >
+      <Chart.Header
+        subtitle="USD thousands · hover a line to inspect its value"
+        title="Revenue against plan"
+      >
+        <Chart.Legend layout="horizontal" />
+      </Chart.Header>
+      <Chart.Plot>
+        <Chart.Grid />
+        <Chart.Axis />
+        <Chart.Series label="Actual" type="line" x="month" y="actual" />
+        <Chart.Series label="Plan" type="line" x="month" y="plan" />
+        <Chart.Cursor />
+      </Chart.Plot>
+    </Chart.Root>
+  ),
+  play: async ({ canvasElement, step }) => {
+    await step(
+      "Hovering actual revenue excludes the plan from its tooltip",
+      async () => {
+        await waitFor(() =>
+          expect(
+            canvasElement.querySelectorAll(".chart-line-series circle"),
+          ).toHaveLength(10),
+        );
+        const point = canvasElement.querySelectorAll(
+          ".chart-line-series circle",
+        )[2];
+        const rect = point.getBoundingClientRect();
+        await userEvent.pointer({
+          target: point,
+          coords: {
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          },
+        });
+        await waitFor(() => {
+          const tooltip = canvasElement.querySelector("[data-chart-tooltip]");
+          expect(tooltip?.textContent).toContain("Actual:61");
+          expect(tooltip?.textContent).not.toContain("Plan");
+        });
+      },
+    );
+  },
+};
+
 const regionalRevenue = [
   {
     region: "North",

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -1068,10 +1068,6 @@ const actualRevenue: RevenueObservation[] = revenuePlan.map((datum, day) => ({
 const dailyRevenue = [...actualRevenue, ...revenuePlan].sort(
   (a, b) => a.date - b.date,
 );
-const revenueSensors = [
-  Chart.sensors.DataHoverSensor({ verticalSlice: false }),
-  Chart.sensors.KeyboardSensor(),
-];
 const revenueBehaviors = [
   Chart.behaviors.Tooltip<RevenueObservation | RevenueObservation[]>({
     render: (reading) => (
@@ -1101,7 +1097,7 @@ export const MultiSeries: Story = {
     docs: {
       description: {
         story:
-          "Compare actual daily revenue with plan in the same USD units over 40 days. d3Config.axes formats numeric UTC timestamps and currency ticks while limiting label density. Each series supplies its own data and tooltip metadata. Single-target pointer hover shows only the selected series; keyboard navigation, cursor, and markers are retained explicitly because custom sensors and behaviors replace the defaults.",
+          "Compare actual daily revenue with plan in the same USD units over 40 days. d3Config.axes formats numeric UTC timestamps and currency ticks while limiting label density. Each series supplies its own data and tooltip metadata. Default hover shows actual revenue and plan together for the same date. The custom tooltip formats both readings, while cursor and markers remain active.",
       },
     },
   },
@@ -1126,13 +1122,12 @@ export const MultiSeries: Story = {
         },
       }}
       data={dailyRevenue}
-      sensors={revenueSensors}
       type="line"
       x="date"
       y="revenue"
     >
       <Chart.Header
-        subtitle="Jan 1 – Feb 9, 2026 · daily totals · hover a line to inspect revenue"
+        subtitle="Jan 1 – Feb 9, 2026 · daily totals · hover to compare actual revenue and plan"
         title="Daily revenue against plan"
       >
         <Chart.Legend layout="horizontal" />
@@ -1173,33 +1168,31 @@ export const MultiSeries: Story = {
         });
       },
     );
-    await step("Each line reports its own dated revenue reading", async () => {
-      const points = canvasElement.querySelectorAll(
-        ".chart-line-series circle",
-      );
-      for (const [index, expected] of [
-        [2, "Actual revenue: $5,100"],
-        [42, "Plan: $4,200"],
-      ] as const) {
-        const point = points[index];
-        const rect = point.getBoundingClientRect();
-        await userEvent.pointer({
-          target: point,
-          coords: {
-            clientX: rect.left + rect.width / 2,
-            clientY: rect.top + rect.height / 2,
-          },
-        });
-        await waitFor(() => {
-          const tooltip = canvasElement.querySelector("[data-chart-tooltip]");
-          expect(tooltip).toHaveTextContent("Jan 3 · UTC");
-          expect(tooltip).toHaveTextContent(expected);
-          expect(tooltip).not.toHaveTextContent(
-            index === 2 ? "Plan:" : "Actual revenue:",
-          );
-        });
-      }
-    });
+    await step(
+      "Hovering either line reports both revenue readings for that date",
+      async () => {
+        const points = canvasElement.querySelectorAll(
+          ".chart-line-series circle",
+        );
+        for (const index of [2, 42]) {
+          const point = points[index];
+          const rect = point.getBoundingClientRect();
+          await userEvent.pointer({
+            target: point,
+            coords: {
+              clientX: rect.left + rect.width / 2,
+              clientY: rect.top + rect.height / 2,
+            },
+          });
+          await waitFor(() => {
+            const tooltip = canvasElement.querySelector("[data-chart-tooltip]");
+            expect(tooltip).toHaveTextContent("Jan 3 · UTC");
+            expect(tooltip).toHaveTextContent("Actual revenue: $5,100");
+            expect(tooltip).toHaveTextContent("Plan: $4,200");
+          });
+        }
+      },
+    );
   },
 };
 

--- a/components/Chart/Chart.tsx
+++ b/components/Chart/Chart.tsx
@@ -32,6 +32,7 @@ export { InputAction, InputSource } from "./engine";
 export type {
   Accessor,
   AxisDomain,
+  AxisOptions,
   ChartProps,
   Config,
   ContextValue,

--- a/components/Chart/subcomponents/Axis/Axis.tsx
+++ b/components/Chart/subcomponents/Axis/Axis.tsx
@@ -1,62 +1,15 @@
 "use strict";
 
+import type { AxisScale } from "d3-axis";
 import { useEffect, useRef } from "react";
 
 import { useChartContext } from "../../context";
 import { d3 } from "../../utils/d3";
 import { yTickCount } from "../../utils/scales";
 import styles from "./Axis.module.scss";
+import { renderAxisTicks } from "./axisTicks";
 
 const X_LABEL_OFFSET = 40;
-
-/** Minimum clear space between neighbouring tick labels. */
-const LABEL_GAP = 8;
-
-/**
- * How many categories to skip so tick labels stop colliding.
- *
- * Band and point scales ignore d3's tick count, so every category is drawn.
- * Measured rather than budgeted: a fixed budget would also thin charts with
- * room to spare.
- */
-const strideToAvoidOverlap = (
-  group: SVGGElement,
-  categories: number,
-  innerWidth: number,
-): number => {
-  if (categories < 2 || innerWidth <= 0) {
-    return 1;
-  }
-
-  let widest = 0;
-  group.querySelectorAll<SVGTextElement>(".tick text").forEach((label) => {
-    try {
-      widest = Math.max(widest, label.getBBox().width);
-    } catch {
-      // Not laid out (no layout engine): fall through to keeping every label.
-    }
-  });
-
-  if (widest === 0) {
-    return 1;
-  }
-
-  const step = innerWidth / categories;
-  return Math.max(1, Math.ceil((widest + LABEL_GAP) / step));
-};
-
-const limitTicks = <T,>(values: T[], limit: number): T[] => {
-  if (values.length <= limit) {
-    return values;
-  }
-  if (limit === 1) {
-    return values.slice(0, 1);
-  }
-  return Array.from(
-    { length: limit },
-    (_, i) => values[Math.round((i * (values.length - 1)) / (limit - 1))],
-  );
-};
 
 export function Axis() {
   const { chartStore, config, requestLayoutAdjustment, isMobile } =
@@ -76,92 +29,27 @@ export function Axis() {
       return;
     }
 
-    const xAxis = d3.axisBottom(xScale as any);
-    const isContinuousX = typeof (xScale as any).ticks === "function";
-
-    const requestedLimit = config.xMaxTicks;
-    const maxTicks =
-      requestedLimit !== undefined &&
-      Number.isFinite(requestedLimit) &&
-      requestedLimit >= 1
-        ? Math.floor(requestedLimit)
-        : undefined;
-    // Bound generation before D3 allocates ticks; xMaxTicks is an upper limit,
-    // not a request to create more labels than the plot can accommodate.
-    const displayBudget = Math.max(1, Math.floor(innerWidth / LABEL_GAP));
-    const tickCount =
-      maxTicks === undefined
-        ? isMobile
-          ? 3
-          : 5
-        : Math.min(maxTicks, displayBudget);
-    let values = isContinuousX
-      ? (xScale as { ticks: (count: number) => number[] }).ticks(tickCount)
-      : (xScale.domain() as (string | number)[]);
-
-    if (isContinuousX) {
-      xAxis.ticks(tickCount);
-    }
-    if (maxTicks !== undefined) {
-      values = limitTicks(values, Math.min(maxTicks, displayBudget));
-    }
-    xAxis.tickValues(values as any);
-    if (config.xTickFormat) {
-      xAxis.tickFormat((value, index) =>
-        config.xTickFormat!(value as string | number, index),
-      );
-    }
-    d3.select(gx.current).call(xAxis);
-
-    if (config.xTickFormat || maxTicks !== undefined) {
-      // Capping can leave uneven gaps, so use the rendered positions. A
-      // formatter may depend on the tick index; recheck after redrawing.
-      while (values.length > 1) {
-        let right = -Infinity;
-        const labels =
-          gx.current.querySelectorAll<SVGTextElement>(".tick text");
-        const visible = values.filter((_, index) => {
-          const rect = labels[index].getBoundingClientRect();
-          if (rect.width === 0) {
-            return true;
-          }
-          if (rect.left < right + LABEL_GAP) {
-            return false;
-          }
-          right = rect.right;
-          return true;
-        });
-        if (visible.length === values.length) {
-          break;
-        }
-        values = visible;
-        xAxis.tickValues(values as any);
-        d3.select(gx.current).call(xAxis);
-      }
-    } else if (!isContinuousX) {
-      const stride = strideToAvoidOverlap(
-        gx.current,
-        values.length,
-        innerWidth,
-      );
-      if (stride > 1) {
-        xAxis.tickValues(values.filter((_, i) => i % stride === 0) as any);
-        d3.select(gx.current).call(xAxis);
-      }
-    }
-
-    const yAxis = d3.axisLeft(yScale as any).ticks(yTickCount(isMobile));
-    if ("ticks" in yScale) {
-      yAxis.tickFormat((d) => {
-        const val = Number(d);
-        if (val === 0) {
-          return "0";
-        }
-        return d3.format(".2s")(val).replace("G", "B");
-      });
-    }
-
-    d3.select(gy.current).call(yAxis);
+    const xAxis = d3.axisBottom(xScale as AxisScale<string | number>);
+    const yAxis = d3.axisLeft(yScale as AxisScale<string | number>);
+    renderAxisTicks(gx.current, xAxis, {
+      direction: "x",
+      length: innerWidth,
+      options: config.axes?.x,
+      defaultTickCount: isMobile ? 3 : 5,
+    });
+    renderAxisTicks(gy.current, yAxis, {
+      direction: "y",
+      length: innerHeight,
+      options: config.axes?.y,
+      defaultTickCount: yTickCount(isMobile),
+      defaultTickFormat:
+        "ticks" in yScale
+          ? (value) => {
+              const val = Number(value);
+              return val === 0 ? "0" : d3.format(".2s")(val).replace("G", "B");
+            }
+          : undefined,
+    });
 
     d3.select(gy.current)
       .selectAll("text")
@@ -206,8 +94,10 @@ export function Axis() {
     config.hideYAxisDomain,
     config.yAxisLabel,
     config.xAxisLabel,
-    config.xTickFormat,
-    config.xMaxTicks,
+    config.axes?.x?.tickFormat,
+    config.axes?.x?.maxTicks,
+    config.axes?.y?.tickFormat,
+    config.axes?.y?.maxTicks,
     isMobile,
     requestLayoutAdjustment,
     innerHeight,

--- a/components/Chart/subcomponents/Axis/Axis.tsx
+++ b/components/Chart/subcomponents/Axis/Axis.tsx
@@ -45,6 +45,19 @@ const strideToAvoidOverlap = (
   return Math.max(1, Math.ceil((widest + LABEL_GAP) / step));
 };
 
+const limitTicks = <T,>(values: T[], limit: number): T[] => {
+  if (values.length <= limit) {
+    return values;
+  }
+  if (limit === 1) {
+    return values.slice(0, 1);
+  }
+  return Array.from(
+    { length: limit },
+    (_, i) => values[Math.round((i * (values.length - 1)) / (limit - 1))],
+  );
+};
+
 export function Axis() {
   const { chartStore, config, requestLayoutAdjustment, isMobile } =
     useChartContext();
@@ -66,23 +79,73 @@ export function Axis() {
     const xAxis = d3.axisBottom(xScale as any);
     const isContinuousX = typeof (xScale as any).ticks === "function";
 
-    if (isContinuousX) {
-      xAxis.ticks(isMobile ? 3 : 5);
-    }
+    const requestedLimit = config.xMaxTicks;
+    const maxTicks =
+      requestedLimit !== undefined &&
+      Number.isFinite(requestedLimit) &&
+      requestedLimit >= 1
+        ? Math.floor(requestedLimit)
+        : undefined;
+    // Bound generation before D3 allocates ticks; xMaxTicks is an upper limit,
+    // not a request to create more labels than the plot can accommodate.
+    const displayBudget = Math.max(1, Math.floor(innerWidth / LABEL_GAP));
+    const tickCount =
+      maxTicks === undefined
+        ? isMobile
+          ? 3
+          : 5
+        : Math.min(maxTicks, displayBudget);
+    let values = isContinuousX
+      ? (xScale as { ticks: (count: number) => number[] }).ticks(tickCount)
+      : (xScale.domain() as (string | number)[]);
 
+    if (isContinuousX) {
+      xAxis.ticks(tickCount);
+    }
+    if (maxTicks !== undefined) {
+      values = limitTicks(values, Math.min(maxTicks, displayBudget));
+    }
+    xAxis.tickValues(values as any);
+    if (config.xTickFormat) {
+      xAxis.tickFormat((value, index) =>
+        config.xTickFormat!(value as string | number, index),
+      );
+    }
     d3.select(gx.current).call(xAxis);
 
-    if (!isContinuousX) {
-      // Draw every category first, then thin only if they actually collide.
-      const domain = (xScale as any).domain() as (string | number)[];
+    if (config.xTickFormat || maxTicks !== undefined) {
+      // Capping can leave uneven gaps, so use the rendered positions. A
+      // formatter may depend on the tick index; recheck after redrawing.
+      while (values.length > 1) {
+        let right = -Infinity;
+        const labels =
+          gx.current.querySelectorAll<SVGTextElement>(".tick text");
+        const visible = values.filter((_, index) => {
+          const rect = labels[index].getBoundingClientRect();
+          if (rect.width === 0) {
+            return true;
+          }
+          if (rect.left < right + LABEL_GAP) {
+            return false;
+          }
+          right = rect.right;
+          return true;
+        });
+        if (visible.length === values.length) {
+          break;
+        }
+        values = visible;
+        xAxis.tickValues(values as any);
+        d3.select(gx.current).call(xAxis);
+      }
+    } else if (!isContinuousX) {
       const stride = strideToAvoidOverlap(
         gx.current,
-        domain.length,
+        values.length,
         innerWidth,
       );
-
       if (stride > 1) {
-        xAxis.tickValues(domain.filter((_, i) => i % stride === 0) as any);
+        xAxis.tickValues(values.filter((_, i) => i % stride === 0) as any);
         d3.select(gx.current).call(xAxis);
       }
     }
@@ -143,9 +206,12 @@ export function Axis() {
     config.hideYAxisDomain,
     config.yAxisLabel,
     config.xAxisLabel,
+    config.xTickFormat,
+    config.xMaxTicks,
     isMobile,
     requestLayoutAdjustment,
     innerHeight,
+    innerWidth,
   ]);
 
   if (!xScale || !yScale) {

--- a/components/Chart/subcomponents/Axis/axisTicks.ts
+++ b/components/Chart/subcomponents/Axis/axisTicks.ts
@@ -1,0 +1,116 @@
+import type { Axis, AxisScale } from "d3-axis";
+
+import { AxisOptions } from "../../types/config";
+import { d3 } from "../../utils/d3";
+import { getAxisTicks, MIN_TICK_GAP } from "../../utils/ticks";
+
+const LABEL_GAP = MIN_TICK_GAP;
+type TickValue = string | number;
+type TickScale = AxisScale<TickValue> & {
+  ticks?: (count: number) => TickValue[];
+};
+
+const strideToAvoidOverlap = (
+  group: SVGGElement,
+  categories: number,
+  innerWidth: number,
+): number => {
+  if (categories < 2 || innerWidth <= 0) {
+    return 1;
+  }
+
+  let widest = 0;
+  group.querySelectorAll<SVGTextElement>(".tick text").forEach((label) => {
+    try {
+      widest = Math.max(widest, label.getBBox().width);
+    } catch {
+      // Not laid out (no layout engine): fall through to keeping every label.
+    }
+  });
+
+  if (widest === 0) {
+    return 1;
+  }
+
+  const step = innerWidth / categories;
+  return Math.max(1, Math.ceil((widest + LABEL_GAP) / step));
+};
+
+interface TickLayout {
+  direction: "x" | "y";
+  length: number;
+  options?: AxisOptions;
+  defaultTickCount: number;
+  defaultTickFormat?: AxisOptions["tickFormat"];
+}
+
+export function renderAxisTicks(
+  group: SVGGElement,
+  axis: Axis<TickValue>,
+  {
+    direction,
+    length,
+    options,
+    defaultTickCount,
+    defaultTickFormat,
+  }: TickLayout,
+) {
+  const scale = axis.scale<TickScale>();
+  const selection = getAxisTicks(
+    scale,
+    length,
+    options?.maxTicks,
+    defaultTickCount,
+  );
+  const { count, maxTicks } = selection;
+  let values = selection.values;
+  axis.ticks(count);
+  axis.tickValues(values);
+  const format = options?.tickFormat ?? defaultTickFormat;
+  if (format) {
+    axis.tickFormat(format);
+  }
+  d3.select(group).call(axis);
+
+  if (options?.tickFormat || maxTicks !== undefined) {
+    // Numeric Y domains often run bottom-to-top. Measure in visual order,
+    // but retain domain order for D3 and index-sensitive formatters.
+    while (values.length > 1) {
+      const boxes = Array.from(
+        group.querySelectorAll<SVGTextElement>(".tick text"),
+        (label, index) => {
+          const rect = label.getBoundingClientRect();
+          return {
+            index,
+            start: direction === "x" ? rect.left : rect.top,
+            end: direction === "x" ? rect.right : rect.bottom,
+          };
+        },
+      ).sort((a, b) => a.start - b.start);
+      let end = -Infinity;
+      const kept = new Set<number>();
+      for (const box of boxes) {
+        if (box.start === box.end) {
+          kept.add(box.index);
+        } else if (box.start >= end + LABEL_GAP) {
+          kept.add(box.index);
+          end = box.end;
+        }
+      }
+      const visible = values.filter((_, index) => kept.has(index));
+      if (visible.length === values.length) {
+        break;
+      }
+      values = visible;
+      axis.tickValues(values);
+      d3.select(group).call(axis);
+    }
+  } else if (direction === "x" && !scale.ticks) {
+    // Preserve the existing unconfigured categorical X-axis treatment.
+    const stride = strideToAvoidOverlap(group, values.length, length);
+    if (stride > 1) {
+      axis.tickValues(values.filter((_, i) => i % stride === 0));
+      d3.select(group).call(axis);
+    }
+  }
+}

--- a/components/Chart/subcomponents/Grid/Grid.tsx
+++ b/components/Chart/subcomponents/Grid/Grid.tsx
@@ -2,6 +2,7 @@
 
 import { useChartContext } from "../../context";
 import { yTickCount } from "../../utils/scales";
+import { getAxisTicks } from "../../utils/ticks";
 import styles from "./Grid.module.scss";
 
 export function Grid() {
@@ -21,11 +22,16 @@ export function Grid() {
   if (!numeric || !("ticks" in numeric)) {
     return null;
   }
-  const ticks = numeric.ticks(yTickCount(isMobile));
+  const { values: ticks } = getAxisTicks<number | Date>(
+    numeric,
+    horizontal ? innerWidth : dimensions.innerHeight,
+    (horizontal ? config.axes?.x : config.axes?.y)?.maxTicks,
+    yTickCount(isMobile),
+  );
 
   return (
     <g data-chart-grid aria-hidden="true" className={styles.grid}>
-      {ticks.map((t: any, i: number) =>
+      {ticks.map((t, i) =>
         horizontal ? (
           <line
             key={i}

--- a/components/Chart/subcomponents/SeriesPoint/SeriesPoint.test.tsx
+++ b/components/Chart/subcomponents/SeriesPoint/SeriesPoint.test.tsx
@@ -36,3 +36,25 @@ describe("SeriesPoint", () => {
     expect(container.querySelector("circle")).toBeNull();
   });
 });
+
+it("keeps datum on the node for hit testing without serializing a DOM attribute", () => {
+  const datum = { value: 42 };
+  const { container, rerender } = render(
+    <svg>
+      <SeriesPoint data-testid="mark" datum={datum} x={10} y={20} />
+    </svg>,
+  );
+  const circle = container.querySelector("circle") as SVGCircleElement & {
+    __data__?: unknown;
+  };
+  expect(circle).not.toHaveAttribute("datum");
+  expect(circle.__data__).toBe(datum);
+  expect(circle).toHaveAttribute("data-testid", "mark");
+  const next = { value: 73 };
+  rerender(
+    <svg>
+      <SeriesPoint datum={next} x={10} y={20} />
+    </svg>,
+  );
+  expect(circle.__data__).toBe(next);
+});

--- a/components/Chart/subcomponents/SeriesPoint/SeriesPoint.tsx
+++ b/components/Chart/subcomponents/SeriesPoint/SeriesPoint.tsx
@@ -30,6 +30,7 @@ export const SeriesPoint = memo(
     className,
     style,
     description,
+    datum,
     ...props
   }: SeriesPointProps) => {
     if (x === undefined || y === undefined || isNaN(x) || isNaN(y)) {
@@ -48,15 +49,12 @@ export const SeriesPoint = memo(
       ...style,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const datum = (props as any).datum;
-
     return (
       <circle
         ref={(node) => {
           if (node) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (node as any).__data__ = datum;
+            (node as SVGCircleElement & { __data__?: unknown }).__data__ =
+              datum;
           }
         }}
         aria-label={description || "Data point"}

--- a/components/Chart/subcomponents/Tooltip/Tooltip.tsx
+++ b/components/Chart/subcomponents/Tooltip/Tooltip.tsx
@@ -145,6 +145,11 @@ function DefaultTooltipContent<T>({
     ? resolveAccessor(category as any)(activeData)
     : undefined;
   const xLabel = category ? String(categoryValue) : "Value";
+  // Built-in sensors already select the complete target set. Only legacy
+  // interactions without any series IDs need category-based reconstruction.
+  const hasIdentifiedTargets = targets?.some(
+    (target) => target.seriesId !== undefined,
+  );
 
   return (
     <Card
@@ -167,6 +172,9 @@ function DefaultTooltipContent<T>({
             const candidate = targets?.find(
               (target) => target.seriesId === item.id,
             );
+            if (hasIdentifiedTargets && !candidate) {
+              return null;
+            }
             const datum =
               item.id === activeSeriesId
                 ? activeData

--- a/components/Chart/types/config.ts
+++ b/components/Chart/types/config.ts
@@ -9,6 +9,10 @@ export interface Config {
   curve?: d3Shape.CurveFactory;
   showAxes?: boolean;
   xAxisLabel?: string;
+  /** Format x-axis labels; numeric timestamps remain numeric scale values. */
+  xTickFormat?: (value: string | number, index: number) => string;
+  /** Positive maximum number of x-axis ticks; labels may be thinned further to fit. */
+  xMaxTicks?: number;
   yAxisLabel?: string;
   grid?: boolean;
   withGradient?: boolean;

--- a/components/Chart/types/config.ts
+++ b/components/Chart/types/config.ts
@@ -2,6 +2,13 @@ import * as d3Shape from "d3-shape";
 
 import { SeriesType } from "./common";
 
+export interface AxisOptions {
+  /** Format labels only; scale values and tooltip data are unchanged. */
+  tickFormat?: (value: string | number, index: number) => string;
+  /** Positive maximum tick count; labels may be thinned further to fit. */
+  maxTicks?: number;
+}
+
 export interface Config {
   margin?: { top: number; right: number; bottom: number; left: number };
   width?: number;
@@ -9,10 +16,7 @@ export interface Config {
   curve?: d3Shape.CurveFactory;
   showAxes?: boolean;
   xAxisLabel?: string;
-  /** Format x-axis labels; numeric timestamps remain numeric scale values. */
-  xTickFormat?: (value: string | number, index: number) => string;
-  /** Positive maximum number of x-axis ticks; labels may be thinned further to fit. */
-  xMaxTicks?: number;
+  axes?: { x?: AxisOptions; y?: AxisOptions };
   yAxisLabel?: string;
   grid?: boolean;
   withGradient?: boolean;

--- a/components/Chart/utils/ticks.ts
+++ b/components/Chart/utils/ticks.ts
@@ -1,0 +1,59 @@
+export const MIN_TICK_GAP = 8;
+
+interface TickSource<T> {
+  domain: () => T[];
+  ticks?: (count: number) => T[];
+}
+
+const limitTicks = <T>(values: T[], limit: number): T[] => {
+  if (values.length <= limit) {
+    return values;
+  }
+  if (limit === 1) {
+    return values.slice(0, 1);
+  }
+  return Array.from(
+    { length: limit },
+    (_, i) => values[Math.round((i * (values.length - 1)) / (limit - 1))],
+  );
+};
+
+/** Shared candidate positions for axes and grid lines, before label collision removal. */
+export function getAxisTicks<T>(
+  scale: TickSource<T>,
+  length: number,
+  requested: number | undefined,
+  defaultCount: number,
+) {
+  const maxTicks =
+    requested !== undefined && Number.isFinite(requested) && requested >= 1
+      ? Math.floor(requested)
+      : undefined;
+  // Cap generation before D3 allocates ticks, not only after labels render.
+  const displayBudget = Math.max(
+    1,
+    Math.floor((Number.isFinite(length) ? length : 0) / MIN_TICK_GAP),
+  );
+  let count =
+    maxTicks === undefined ? defaultCount : Math.min(maxTicks, displayBudget);
+  let candidates = scale.ticks ? scale.ticks(count) : scale.domain();
+  const limit =
+    maxTicks === undefined ? undefined : Math.min(maxTicks, displayBudget);
+  // Continuous ticks should keep D3's regular intervals, rather than develop
+  // gaps from sampling individual values out of an otherwise uniform grid.
+  while (
+    scale.ticks &&
+    limit !== undefined &&
+    candidates.length > limit &&
+    count > 1
+  ) {
+    count = Math.max(
+      1,
+      Math.min(count - 1, Math.floor((count * limit) / candidates.length)),
+    );
+    candidates = scale.ticks(count);
+  }
+  const values =
+    limit === undefined ? candidates : limitTicks(candidates, limit);
+  return { values, count, maxTicks };
+}

--- a/skills/doom-design-system/components/chart.md
+++ b/skills/doom-design-system/components/chart.md
@@ -47,12 +47,17 @@ component's own semantics win on conflict.
 | `curve` | `d3Shape.CurveFactory` | — | D3 curve factory (e.g. `curveMonotoneX`) |
 | `showAxes` | `boolean` | `true` | Show X/Y axes |
 | `xAxisLabel` | `string` | — | X-axis label text |
+| `xTickFormat` | `(value: string \| number, index: number) => string` | — | Format X tick labels; numeric timestamps can be formatted with an explicit locale/timezone. |
+| `xMaxTicks` | `number` | — | Maximum X tick count; positive values are floored, invalid values ignored. Labels may be thinned further to fit. |
 | `yAxisLabel` | `string` | — | Y-axis label text |
 | `grid` | `boolean` | — | Show grid lines |
 | `withGradient` | `boolean` | — | Fill area with gradient |
 | `showDots` | `boolean` | — | Show data point dots |
 | `hideYAxisDomain` | `boolean` | — | Hide Y-axis domain line |
 | `type` | `SeriesType` | — | Series type override within config |
+
+Numeric timestamps use the existing linear scale, not calendar-aligned time ticks.
+`xTickFormat` changes labels only; it does not change tooltip data or scale values.
 
 ## Usage
 
@@ -299,6 +304,10 @@ import {
 Chart.sensors;    // DataHoverSensor, KeyboardSensor, DragSensor, SelectionSensor
 Chart.behaviors;  // Tooltip, Cursor, Markers, Dim, DraggablePuck, SelectionUpdate
 ```
+
+The default tooltip displays the sensor's selected targets. Use
+`Chart.sensors.DataHoverSensor({ verticalSlice: false })` for a single-point
+tooltip, and retain `Chart.sensors.KeyboardSensor()` for keyboard interaction.
 
 `sensors` and `behaviors` **replace** the defaults rather than adding to them,
 so compose from the built-ins when you want a partial override:

--- a/skills/doom-design-system/components/chart.md
+++ b/skills/doom-design-system/components/chart.md
@@ -47,8 +47,7 @@ component's own semantics win on conflict.
 | `curve` | `d3Shape.CurveFactory` | — | D3 curve factory (e.g. `curveMonotoneX`) |
 | `showAxes` | `boolean` | `true` | Show X/Y axes |
 | `xAxisLabel` | `string` | — | X-axis label text |
-| `xTickFormat` | `(value: string \| number, index: number) => string` | — | Format X tick labels; numeric timestamps can be formatted with an explicit locale/timezone. |
-| `xMaxTicks` | `number` | — | Maximum X tick count; positive values are floored, invalid values ignored. Labels may be thinned further to fit. |
+| `axes` | `{ x?: AxisOptions; y?: AxisOptions }` | — | Per-axis tick formatting and label limits using the same options for either axis. |
 | `yAxisLabel` | `string` | — | Y-axis label text |
 | `grid` | `boolean` | — | Show grid lines |
 | `withGradient` | `boolean` | — | Fill area with gradient |
@@ -57,7 +56,20 @@ component's own semantics win on conflict.
 | `type` | `SeriesType` | — | Series type override within config |
 
 Numeric timestamps use the existing linear scale, not calendar-aligned time ticks.
-`xTickFormat` changes labels only; it does not change tooltip data or scale values.
+`axes.x.tickFormat` and `axes.y.tickFormat` change labels only, not scale values
+or tooltip data. Both accept `(value: string | number, index: number) => string`.
+Each axis accepts `maxTicks`: positive values are floored, invalid values ignored,
+and labels may be thinned further to fit. Unconfigured axes keep their defaults.
+Existing `xAxisLabel`, `yAxisLabel`, and domain props remain unchanged.
+
+```tsx
+d3Config={{
+  axes: {
+    x: { tickFormat: value => dateFormat.format(Number(value)), maxTicks: 6 },
+    y: { tickFormat: value => currencyFormat.format(Number(value)), maxTicks: 5 },
+  },
+}}
+```
 
 ## Usage
 

--- a/tests/browser/Chart/axis.test.tsx
+++ b/tests/browser/Chart/axis.test.tsx
@@ -15,8 +15,8 @@ const data = Array.from({ length: 40 }, (_, i) => ({
 }));
 const dateLabel = (value: string | number) =>
   new Date(Number(value)).toISOString().slice(0, 10);
-const labels = (host: HTMLElement) =>
-  Array.from(host.querySelectorAll('[aria-label="X Axis"] .tick text'));
+const labels = (host: HTMLElement, axis: "X" | "Y" = "X") =>
+  Array.from(host.querySelectorAll(`[aria-label="${axis} Axis"] .tick text`));
 
 afterEach(cleanup);
 
@@ -24,7 +24,10 @@ it("formats timestamp ticks and caps their count without changing the data", asy
   const { container } = render(
     <DesignSystemProvider>
       <Chart
-        d3Config={{ showDots: true, xTickFormat: dateLabel, xMaxTicks: 4 }}
+        d3Config={{
+          showDots: true,
+          axes: { x: { tickFormat: dateLabel, maxTicks: 4 } },
+        }}
         data={data}
         style={{ width: 1000, height: 360 }}
         type="line"
@@ -51,8 +54,12 @@ it("updates formatting and categorical tick limits after a parent rerender", asy
     <DesignSystemProvider>
       <Chart
         d3Config={{
-          xTickFormat: (value) => `${prefix}${value}`,
-          xMaxTicks: count,
+          axes: {
+            x: {
+              tickFormat: (value) => `${prefix}${value}`,
+              maxTicks: count,
+            },
+          },
         }}
         data={rows}
         style={{ width: 1400, height: 360 }}
@@ -81,7 +88,7 @@ it("keeps long formatted labels from overlapping in a narrow chart", async () =>
   const { container } = render(
     <DesignSystemProvider>
       <Chart
-        d3Config={{ xTickFormat: dateLabel, xMaxTicks: 20 }}
+        d3Config={{ axes: { x: { tickFormat: dateLabel, maxTicks: 20 } } }}
         data={data}
         style={{ width: 360, height: 360 }}
         type="line"
@@ -107,7 +114,7 @@ it("handles one tick and ignores invalid tick limits", async () => {
   const example = (limit: number) => (
     <DesignSystemProvider>
       <Chart
-        d3Config={{ xMaxTicks: limit }}
+        d3Config={{ axes: { x: { maxTicks: limit } } }}
         data={data}
         style={{ width: 1000, height: 360 }}
         type="line"
@@ -130,7 +137,7 @@ it.each([240, 500, 800])(
     const { container } = render(
       <DesignSystemProvider>
         <Chart
-          d3Config={{ xTickFormat: dateLabel, xMaxTicks: 6 }}
+          d3Config={{ axes: { x: { tickFormat: dateLabel, maxTicks: 6 } } }}
           data={data}
           style={{ width, height: 360 }}
           type="line"
@@ -161,7 +168,7 @@ it.each([500, 640, 680])(
     const { container } = render(
       <DesignSystemProvider>
         <Chart
-          d3Config={{ xMaxTicks: 6 }}
+          d3Config={{ axes: { x: { maxTicks: 6 } } }}
           data={rows}
           style={{ width, height: 360 }}
           type="bar"
@@ -185,7 +192,7 @@ it("keeps huge finite tick limits bounded by available display space", async () 
   const { container } = render(
     <DesignSystemProvider>
       <Chart
-        d3Config={{ xMaxTicks: Number.MAX_SAFE_INTEGER }}
+        d3Config={{ axes: { x: { maxTicks: Number.MAX_SAFE_INTEGER } } }}
         data={[
           { x: 0, y: 1 },
           { x: 1, y: 2 },
@@ -202,3 +209,227 @@ it("keeps huge finite tick limits bounded by available display space", async () 
     expect(labels(container).length).toBeLessThan(100);
   });
 });
+
+it("formats both numeric axes independently and restores Y defaults after rerender", async () => {
+  const example = (customY: boolean) => (
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{
+          axes: {
+            x: { tickFormat: dateLabel, maxTicks: 4 },
+            y: customY
+              ? {
+                  tickFormat: (value) =>
+                    `$${Number(value).toLocaleString("en-US")}`,
+                  maxTicks: 3,
+                }
+              : undefined,
+          },
+        }}
+        data={data.map((row) => ({ ...row, y: row.y * 1000 }))}
+        style={{ width: 1000, height: 400 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>
+  );
+  const { container, rerender } = render(example(true));
+  await waitFor(() => {
+    expect(
+      labels(container).every((label) =>
+        /^2026-/.test(label.textContent ?? ""),
+      ),
+    ).toBe(true);
+    expect(labels(container, "Y").length).toBeGreaterThan(1);
+    expect(labels(container, "Y").length).toBeLessThanOrEqual(3);
+    expect(
+      labels(container, "Y").every((label) =>
+        label.textContent?.startsWith("$"),
+      ),
+    ).toBe(true);
+  });
+  rerender(example(false));
+  await waitFor(() => {
+    expect(
+      labels(container, "Y").some((label) => label.textContent?.includes("k")),
+    ).toBe(true);
+    expect(
+      labels(container, "Y").every(
+        (label) => !label.textContent?.startsWith("$"),
+      ),
+    ).toBe(true);
+  });
+});
+
+it("formats and thins Y categories on horizontal bars without omitting bars", async () => {
+  const rows = Array.from({ length: 18 }, (_, i) => ({
+    category: `Team ${i + 1}`,
+    value: i + 10,
+  }));
+  const { container } = render(
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{
+          axes: {
+            y: { tickFormat: (value) => `Group: ${value}`, maxTicks: 7 },
+          },
+        }}
+        data={rows}
+        style={{ width: 600, height: 320 }}
+        type="bar"
+        x="value"
+        y="category"
+      >
+        <Chart.Plot>
+          <Chart.Series orientation="horizontal" type="bar" />
+          <Chart.Axis />
+        </Chart.Plot>
+      </Chart>
+    </DesignSystemProvider>,
+  );
+  await waitFor(() => {
+    const ticks = labels(container, "Y");
+    expect(ticks.length).toBeGreaterThan(1);
+    expect(ticks.length).toBeLessThanOrEqual(7);
+    expect(ticks.every((tick) => tick.textContent?.startsWith("Group:"))).toBe(
+      true,
+    );
+    const boxes = ticks
+      .map((t) => t.getBoundingClientRect())
+      .sort((a, b) => a.top - b.top);
+    for (let i = 1; i < boxes.length; i++) {
+      expect(boxes[i].top).toBeGreaterThanOrEqual(boxes[i - 1].bottom + 7);
+    }
+    expect(container.querySelectorAll(".chart-bar")).toHaveLength(18);
+  });
+});
+
+it.each([1, 2.9, Number.MAX_SAFE_INTEGER, 0, -1, NaN, Infinity])(
+  "validates Y tick limits consistently (%s)",
+  async (maxTicks) => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart
+          d3Config={{ axes: { y: { maxTicks } } }}
+          data={data}
+          style={{ width: 500, height: 250 }}
+          type="line"
+          x="x"
+          y="y"
+        />
+      </DesignSystemProvider>,
+    );
+    await waitFor(() => {
+      const ticks = labels(container, "Y");
+      expect(ticks.length).toBeGreaterThan(0);
+      if (Number.isFinite(maxTicks) && maxTicks >= 1) {
+        expect(ticks.length).toBeLessThanOrEqual(Math.floor(maxTicks));
+      }
+      if (maxTicks === 1) {
+        expect(ticks).toHaveLength(1);
+      }
+      const boxes = ticks
+        .map((t) => t.getBoundingClientRect())
+        .sort((a, b) => a.top - b.top);
+      for (let i = 1; i < boxes.length; i++) {
+        expect(boxes[i].top).toBeGreaterThanOrEqual(boxes[i - 1].bottom);
+      }
+    });
+  },
+);
+
+it.each([false, true])(
+  "aligns grid lines with configured numeric ticks (horizontal=%s)",
+  async (horizontal) => {
+    const rows = [
+      { category: "A", value: 25 },
+      { category: "B", value: 75 },
+    ];
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart
+          d3Config={{ axes: { [horizontal ? "x" : "y"]: { maxTicks: 3 } } }}
+          data={rows}
+          style={{ width: 600, height: 360 }}
+          type={horizontal ? "bar" : "line"}
+          x={horizontal ? "value" : "category"}
+          xDomain={horizontal ? [0, 100] : undefined}
+          y={horizontal ? "category" : "value"}
+          yDomain={horizontal ? undefined : [0, 100]}
+        >
+          <Chart.Plot>
+            <Chart.Grid />
+            <Chart.Axis />
+            <Chart.Series
+              orientation={horizontal ? "horizontal" : "vertical"}
+              type={horizontal ? "bar" : "line"}
+            />
+          </Chart.Plot>
+        </Chart>
+      </DesignSystemProvider>,
+    );
+    await waitFor(() => {
+      const axis = horizontal ? "X" : "Y";
+      const ticks = Array.from(
+        container.querySelectorAll<SVGGElement>(
+          `[aria-label="${axis} Axis"] .tick`,
+        ),
+      );
+      const positions = ticks.map((tick) => {
+        const matrix = tick.transform.baseVal.consolidate()!.matrix;
+        return horizontal ? matrix.e : matrix.f;
+      });
+      const grid = Array.from(
+        container.querySelectorAll("[data-chart-grid] line"),
+        (line) => Number(line.getAttribute(horizontal ? "x1" : "y1")),
+      );
+      expect(positions).toHaveLength(3);
+      expect(grid).toHaveLength(3);
+      positions.forEach((position, i) =>
+        expect(grid[i]).toBeCloseTo(position - 0.5, 3),
+      );
+    });
+  },
+);
+
+it.each(["x", "y"] as const)(
+  "retains regular numeric intervals when capping %s ticks",
+  async (direction) => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart
+          d3Config={{
+            axes: {
+              [direction]: {
+                maxTicks: 5,
+                tickFormat: (value: string | number) => String(value),
+              },
+            },
+          }}
+          data={[
+            { x: 0, y: 0 },
+            { x: 1000, y: 1000 },
+          ]}
+          style={{ width: 1000, height: 500 }}
+          type="line"
+          x="x"
+          xDomain={[0, 1000]}
+          y="y"
+          yDomain={[0, 1000]}
+        />
+      </DesignSystemProvider>,
+    );
+    await waitFor(() => {
+      const values = labels(container, direction === "x" ? "X" : "Y").map(
+        (label) => Number(label.textContent),
+      );
+      expect(values.length).toBeGreaterThan(2);
+      expect(values.length).toBeLessThanOrEqual(5);
+      const step = values[1] - values[0];
+      for (let i = 2; i < values.length; i++) {
+        expect(values[i] - values[i - 1]).toBe(step);
+      }
+    });
+  },
+);

--- a/tests/browser/Chart/axis.test.tsx
+++ b/tests/browser/Chart/axis.test.tsx
@@ -1,0 +1,204 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, expect, it } from "vitest";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+const day = 86400000;
+const start = Date.UTC(2026, 0, 1);
+const data = Array.from({ length: 40 }, (_, i) => ({
+  x: start + i * day,
+  y: 20 + (i % 7),
+}));
+const dateLabel = (value: string | number) =>
+  new Date(Number(value)).toISOString().slice(0, 10);
+const labels = (host: HTMLElement) =>
+  Array.from(host.querySelectorAll('[aria-label="X Axis"] .tick text'));
+
+afterEach(cleanup);
+
+it("formats timestamp ticks and caps their count without changing the data", async () => {
+  const { container } = render(
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{ showDots: true, xTickFormat: dateLabel, xMaxTicks: 4 }}
+        data={data}
+        style={{ width: 1000, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>,
+  );
+  await waitFor(() => {
+    expect(labels(container).length).toBeGreaterThan(1);
+    expect(labels(container).length).toBeLessThanOrEqual(4);
+    expect(
+      labels(container).every((label) =>
+        /^2026-\d\d-\d\d$/.test(label.textContent ?? ""),
+      ),
+    ).toBe(true);
+    expect(container.querySelectorAll("circle")).toHaveLength(data.length);
+  });
+});
+
+it("updates formatting and categorical tick limits after a parent rerender", async () => {
+  const rows = data.map((d, i) => ({ ...d, x: `Day ${i + 1}` }));
+  const example = (prefix: string, count: number) => (
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{
+          xTickFormat: (value) => `${prefix}${value}`,
+          xMaxTicks: count,
+        }}
+        data={rows}
+        style={{ width: 1400, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>
+  );
+  const { container, rerender } = render(example("Before ", 5));
+  await waitFor(() => {
+    expect(labels(container)).toHaveLength(5);
+    expect(labels(container)[0].textContent).toBe("Before Day 1");
+    expect(labels(container).at(-1)?.textContent).toBe("Before Day 40");
+  });
+  rerender(example("After ", 2));
+  await waitFor(() => {
+    expect(labels(container).map((label) => label.textContent)).toEqual([
+      "After Day 1",
+      "After Day 40",
+    ]);
+  });
+});
+
+it("keeps long formatted labels from overlapping in a narrow chart", async () => {
+  const { container } = render(
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{ xTickFormat: dateLabel, xMaxTicks: 20 }}
+        data={data}
+        style={{ width: 360, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>,
+  );
+  await waitFor(() => {
+    const ticks = labels(container);
+    expect(ticks.length).toBeGreaterThan(1);
+    expect(ticks.every((tick) => /^2026-/.test(tick.textContent ?? ""))).toBe(
+      true,
+    );
+    const bounds = ticks.map((tick) => tick.getBoundingClientRect());
+    for (let i = 1; i < bounds.length; i++) {
+      expect(bounds[i].left).toBeGreaterThanOrEqual(bounds[i - 1].right);
+    }
+  });
+});
+
+it("handles one tick and ignores invalid tick limits", async () => {
+  const example = (limit: number) => (
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{ xMaxTicks: limit }}
+        data={data}
+        style={{ width: 1000, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>
+  );
+  const { container, rerender } = render(example(1));
+  await waitFor(() => expect(labels(container)).toHaveLength(1));
+  for (const invalid of [0, -2, NaN, Infinity]) {
+    rerender(example(invalid));
+    await waitFor(() => expect(labels(container).length).toBeGreaterThan(1));
+  }
+});
+
+it.each([240, 500, 800])(
+  "keeps formatted ticks separated at %ipx",
+  async (width) => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart
+          d3Config={{ xTickFormat: dateLabel, xMaxTicks: 6 }}
+          data={data}
+          style={{ width, height: 360 }}
+          type="line"
+          x="x"
+          y="y"
+        />
+      </DesignSystemProvider>,
+    );
+    await waitFor(() => {
+      const ticks = labels(container);
+      expect(ticks.length).toBeGreaterThan(0);
+      expect(ticks.length).toBeLessThanOrEqual(6);
+      const bounds = ticks.map((tick) => tick.getBoundingClientRect());
+      for (let i = 1; i < bounds.length; i++) {
+        expect(bounds[i].left).toBeGreaterThanOrEqual(bounds[i - 1].right);
+      }
+    });
+  },
+);
+
+it.each([500, 640, 680])(
+  "does not overlap capped category labels at %ipx",
+  async (width) => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      x: `Category ${i + 1}`,
+      y: i + 1,
+    }));
+    const { container } = render(
+      <DesignSystemProvider>
+        <Chart
+          d3Config={{ xMaxTicks: 6 }}
+          data={rows}
+          style={{ width, height: 360 }}
+          type="bar"
+          x="x"
+          y="y"
+        />
+      </DesignSystemProvider>,
+    );
+    await waitFor(() => {
+      const ticks = labels(container);
+      expect(ticks.length).toBeGreaterThan(1);
+      const boxes = ticks.map((tick) => tick.getBoundingClientRect());
+      for (let i = 1; i < boxes.length; i++) {
+        expect(boxes[i].left).toBeGreaterThanOrEqual(boxes[i - 1].right + 7);
+      }
+    });
+  },
+);
+
+it("keeps huge finite tick limits bounded by available display space", async () => {
+  const { container } = render(
+    <DesignSystemProvider>
+      <Chart
+        d3Config={{ xMaxTicks: Number.MAX_SAFE_INTEGER }}
+        data={[
+          { x: 0, y: 1 },
+          { x: 1, y: 2 },
+        ]}
+        style={{ width: 500, height: 360 }}
+        type="line"
+        x="x"
+        y="y"
+      />
+    </DesignSystemProvider>,
+  );
+  await waitFor(() => {
+    expect(labels(container).length).toBeGreaterThan(0);
+    expect(labels(container).length).toBeLessThan(100);
+  });
+});

--- a/tests/browser/Chart/tooltip.test.tsx
+++ b/tests/browser/Chart/tooltip.test.tsx
@@ -1,0 +1,240 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { Sensor } from "../../../components/Chart/types/events";
+import { HoverInteraction } from "../../../components/Chart/types/interaction";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+afterEach(cleanup);
+
+const actual = [
+  { category: "A", value: 10 },
+  { category: "B", value: -20 },
+  { category: "C", value: 15 },
+];
+const projection = [
+  { category: "C", value: 35 },
+  { category: "A", value: 30 },
+  { category: "B", value: -40 },
+];
+const sparse = [{ category: "B", value: -60 }];
+const single = () => [
+  Chart.sensors.DataHoverSensor({ verticalSlice: false }),
+  Chart.sensors.KeyboardSensor(),
+];
+
+function Example({
+  sensors,
+  horizontal = false,
+  bars = false,
+  custom = false,
+}: {
+  sensors?: Sensor[];
+  horizontal?: boolean;
+  bars?: boolean;
+  custom?: boolean;
+}) {
+  return (
+    <DesignSystemProvider>
+      <Chart
+        behaviors={[
+          Chart.behaviors.Tooltip({
+            render: custom
+              ? (rows) => <output>{JSON.stringify(rows)}</output>
+              : undefined,
+          }),
+        ]}
+        d3Config={{ showDots: true }}
+        data={actual}
+        sensors={sensors}
+        style={{ width: 650, height: 400 }}
+        type={bars ? "bar" : "line"}
+        x={horizontal ? "value" : "category"}
+        y={horizontal ? "category" : "value"}
+        yDomain={bars ? undefined : [-80, 50]}
+      >
+        <Chart.Plot>
+          {[
+            { id: "actual", label: "Actual", data: actual },
+            { id: "projection", label: "Projection", data: projection },
+            { id: "sparse", label: "Sparse", data: sparse },
+          ].map((series) => (
+            <Chart.Series
+              key={series.id}
+              {...series}
+              barWidth={20}
+              orientation={horizontal ? "horizontal" : "vertical"}
+              stackId={bars ? "total" : undefined}
+              type={bars ? "bar" : "line"}
+            />
+          ))}
+        </Chart.Plot>
+      </Chart>
+    </DesignSystemProvider>
+  );
+}
+
+async function mount(props: Parameters<typeof Example>[0] = {}) {
+  const { container } = render(<Example {...props} />);
+  const marks = () =>
+    container.querySelectorAll(props.bars ? ".chart-bar" : "circle");
+  await expect.poll(() => marks().length).toBe(7);
+  await expect
+    .poll(() => marks()[1].getBoundingClientRect().width)
+    .toBeGreaterThan(0);
+  const text = () =>
+    container.querySelector("[data-chart-tooltip]")?.textContent;
+  return { container, marks, text };
+}
+
+it("shows only the pointer target with verticalSlice:false, including a sparse series", async () => {
+  const { marks, text } = await mount({ sensors: single() });
+  await userEvent.hover(marks()[1]);
+  await expect.poll(text).toBe("BActual:-20");
+  await userEvent.hover(marks()[6], {
+    position: {
+      x: marks()[6].getBoundingClientRect().width / 2,
+      y: marks()[6].getBoundingClientRect().height / 2 - 2,
+    },
+  });
+  await expect.poll(text).toBe("BSparse:-60");
+});
+
+it("preserves default slices using each series' own row and omits absent sparse rows", async () => {
+  const { marks, text } = await mount();
+  await userEvent.hover(marks()[1]);
+  await expect.poll(text).toBe("BActual:-20Projection:-40Sparse:-60");
+  await userEvent.hover(marks()[0], {
+    position: {
+      x: marks()[0].getBoundingClientRect().width / 2 + 2,
+      y: marks()[0].getBoundingClientRect().height / 2,
+    },
+  });
+  await expect.poll(text).toBe("AActual:10Projection:30");
+});
+
+it.each([false, true])(
+  "restricts signed bars to the target (horizontal=%s)",
+  async (horizontal) => {
+    const { marks, text } = await mount({
+      sensors: single(),
+      bars: true,
+      horizontal,
+    });
+    await userEvent.hover(marks()[1]);
+    await expect.poll(text).toBe("BActual:-20");
+    await userEvent.hover(marks()[4]);
+    await expect.poll(text).toBe("AProjection:30");
+  },
+);
+
+it("preserves keyboard slices and Escape after single-target pointer input", async () => {
+  const { container, marks, text } = await mount({ sensors: single() });
+  await userEvent.hover(marks()[1]);
+  await userEvent.hover(document.body);
+  await expect.poll(text).toBeUndefined();
+  container.querySelector<HTMLElement>("[data-chart-container]")!.focus();
+  await userEvent.keyboard("{ArrowRight}");
+  await expect.poll(text).toBe("AActual:10Projection:30");
+  await userEvent.keyboard("{ArrowRight}");
+  await expect.poll(text).toBe("BActual:-20Projection:-40Sparse:-60");
+  await userEvent.keyboard("{Escape}");
+  await expect.poll(text).toBeUndefined();
+});
+
+it.each([false, true])(
+  "preserves custom renderer payloads (slice=%s)",
+  async (slice) => {
+    const { marks, text } = await mount({
+      custom: true,
+      sensors: slice ? undefined : single(),
+    });
+    await userEvent.hover(marks()[1]);
+    await expect
+      .poll(() => JSON.parse(text() ?? "null"))
+      .toEqual(slice ? [actual[1], projection[2], sparse[0]] : actual[1]);
+  },
+);
+
+// Exercise public custom sensors through the real pointer pipeline. The built-in
+// producers supply IDs; older/custom sensors may omit them.
+function transformTargets(
+  transform: (
+    targets: HoverInteraction["targets"],
+  ) => HoverInteraction["targets"],
+  sensor: Sensor = Chart.sensors.DataHoverSensor({ verticalSlice: true }),
+): Sensor {
+  return (event, context) =>
+    sensor(event, {
+      ...context,
+      upsertInteraction: (name, interaction) => {
+        const state = interaction as HoverInteraction;
+        context.upsertInteraction(name, {
+          ...state,
+          targets: transform(state.targets),
+        });
+      },
+    });
+}
+
+it("does not recreate a series excluded from an explicit multi-target slice", async () => {
+  const sensors = [
+    transformTargets((targets) =>
+      targets.filter((target) => target.data !== projection[2]),
+    ),
+  ];
+  const { marks, text } = await mount({ sensors });
+  await userEvent.hover(marks()[1]);
+  await expect.poll(text).toBe("BActual:-20Sparse:-60");
+});
+
+it("keeps legacy category lookup when every target lacks a series ID", async () => {
+  const sensors = [
+    transformTargets((targets) => [{ ...targets[0], seriesId: undefined }]),
+  ];
+  const { marks, text } = await mount({ sensors });
+  await userEvent.hover(marks()[1]);
+  await expect.poll(text).toBe("BActual:-20Projection:-40Sparse:-60");
+});
+
+it("does not let an unidentified target expand an otherwise identified slice", async () => {
+  const sensors = [
+    transformTargets((targets) =>
+      targets.map((target) =>
+        target.data === projection[2]
+          ? { ...target, seriesId: undefined }
+          : target,
+      ),
+    ),
+  ];
+  const { marks, text } = await mount({ sensors });
+  await userEvent.hover(marks()[1]);
+  await expect.poll(text).toBe("BActual:-20Sparse:-60");
+});
+
+it.each([false, true])(
+  "honors a single keyboard target (custom=%s)",
+  async (custom) => {
+    const sensors = [
+      transformTargets(
+        (targets) => targets.slice(0, 1),
+        Chart.sensors.KeyboardSensor(),
+      ),
+    ];
+    const { container, text } = await mount({ sensors, custom });
+    await userEvent.hover(document.body);
+    container.querySelector<HTMLElement>("[data-chart-container]")!.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    await expect
+      .poll(text)
+      .toBe(custom ? JSON.stringify(actual[0]) : "AActual:10");
+    await userEvent.keyboard("{ArrowRight}");
+    await expect
+      .poll(text)
+      .toBe(custom ? JSON.stringify(actual[1]) : "BActual:-20");
+  },
+);


### PR DESCRIPTION
Chart now respects the sensor's selected tooltip targets and provides a shared axis configuration for both X and Y:

```tsx
d3Config={{
  axes: {
    x: { tickFormat: formatDate, maxTicks: 6 },
    y: { tickFormat: formatCurrency, maxTicks: 5 },
  },
}}
```

`AxisOptions` is exported for reuse. Axes share validation, bounded tick generation, and direction-aware label collision handling; grid lines use the same candidate positions. Capped numeric ticks retain regular D3 intervals. Existing axis-label props and unconfigured defaults remain compatible. Numeric timestamps continue to use the linear scale; formatting does not introduce Date parsing or calendar-aligned time ticks.

Default tooltips show only identified interaction targets while preserving default pointer/keyboard slices and legacy ID-less custom sensors. SeriesPoint retains its hit-testing datum without serializing it onto the SVG circle.

The existing MultiSeries story demonstrates actual revenue against plan with date and currency axes, a legend, and dated all-series tooltips. No new story entries or Markdown documents are introduced; edge cases live in the browser suite.

Validation:
- Red/green regressions for tooltip targeting, datum serialization, both axes' configuration, category overlap, huge limits, grid alignment, and regular numeric tick intervals.
- 903 unit tests and 125 Chromium browser tests passed. Native Playwright hover and keyboard tests cover tooltip targets, sparse/reordered series, signed bars, and custom renderers.
- 235 static Storybook tests passed, including 6 interaction stories. After restoring MultiSeries to default slice hover, its updated assertion failed with the old single-series override and all 6 interaction stories passed after removing that override. MultiSeries visually checked at desktop and mobile widths.
- Production build, package validation, publint, and all 3 package-import tests passed. Lint has zero errors and 457 existing warnings.
- Full-project TypeScript diagnostics match main's existing test-fixture errors. Existing Storybook accessibility warnings remain warnings.
- Clean-source verification excluded local untracked duplicate files, which were preserved. Independent review cleared the final axis implementation.

Fixes #78

