### PR TITLE
Chart: keep behavior context and margin overrides current

### DIFF
--- a/components/Chart/hooks/useChartBehaviors.test.tsx
+++ b/components/Chart/hooks/useChartBehaviors.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from "@testing-library/react";
+import { expect, it } from "vitest";
+
+import { createChartStore } from "../state/store/chart.store";
+import type { ContextValue } from "../types/context";
+import type { Behavior, BehaviorContext } from "../types/events";
+import { useChartBehaviors } from "./useChartBehaviors";
+import { useEngine } from "./useEngine";
+
+it("gives an active behavior live configuration without resetting its closure", () => {
+  const chartStore = createChartStore({ type: "line" });
+  const plot = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  chartStore.setState((state) => ({
+    status: "ready",
+    elements: { ...state.elements, plot },
+  }));
+  let read!: () => {
+    context: ReturnType<BehaviorContext["getChartContext"]>;
+    count: number;
+  };
+  let setups = 0;
+  let cleanups = 0;
+  const behavior: Behavior = (context) => {
+    setups++;
+    let count = 0;
+    read = () => ({ context: context.getChartContext(), count: ++count });
+    return () => {
+      cleanups++;
+    };
+  };
+  const { rerender, unmount } = renderHook(
+    ({ label, isMobile }) => {
+      const { engine } = useEngine();
+      const context: ContextValue = {
+        chartStore,
+        engine,
+        config: { type: "line", yAxisLabel: label },
+        isMobile,
+        colorPalette: [label],
+        styles: {},
+        resolveInteraction: () => null,
+      };
+      useChartBehaviors(context, [behavior]);
+    },
+    { initialProps: { label: "Before", isMobile: false } },
+  );
+  const initialRead = read;
+  expect(read().count).toBe(1);
+  rerender({ label: "After", isMobile: true });
+  const next = read();
+  expect(next.context.config.yAxisLabel).toBe("After");
+  expect(next.context.isMobile).toBe(true);
+  expect(next.context.colorPalette).toEqual(["After"]);
+  expect(next.context.g?.node()).toBe(plot);
+  expect(read).toBe(initialRead);
+  expect(next.count).toBe(2);
+  expect(setups).toBe(1);
+  expect(cleanups).toBe(0);
+  act(() => unmount());
+  expect(cleanups).toBe(1);
+});

--- a/components/Chart/hooks/useChartBehaviors.ts
+++ b/components/Chart/hooks/useChartBehaviors.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 
 import { Cursor, Dim, Markers, Tooltip } from "../behaviors";
 import {
@@ -14,6 +14,11 @@ export const useChartBehaviors = <T>(
   chartContext: ContextValue<T>,
   userBehaviors?: Behavior<T>[],
 ) => {
+  const contextRef = useRef(chartContext);
+  useLayoutEffect(() => {
+    contextRef.current = chartContext;
+  });
+
   // Consumers pass a fresh array literal every render. Keying off its identity
   // would tear down and re-append every d3 layer on any unrelated re-render.
   const behaviorsRef = useRef<Behavior<T>[] | undefined>(userBehaviors);
@@ -94,7 +99,7 @@ export const useChartBehaviors = <T>(
       return behavior({
         getChartContext: () =>
           ({
-            ...chartContext,
+            ...contextRef.current,
             g: gSelection,
           }) as any,
         getInteraction: (name: string) => {

--- a/components/Chart/subcomponents/Root/Root.margin.test.tsx
+++ b/components/Chart/subcomponents/Root/Root.margin.test.tsx
@@ -1,0 +1,74 @@
+import { render } from "@testing-library/react";
+import { expect, it } from "vitest";
+
+import { useChartContext } from "../../context";
+import type { Config, ContextValue } from "../../types";
+import { Root } from "./Root";
+
+const rows = [
+  { x: 0, y: 10 },
+  { x: 1, y: 20 },
+];
+
+it.each([true, false])(
+  "adds, replaces, removes and reapplies margins (showAxes=%s)",
+  (showAxes) => {
+    let context!: ContextValue;
+    function Capture() {
+      context = useChartContext();
+      return null;
+    }
+    const example = (margin?: Config["margin"]) => (
+      <Root
+        data={rows}
+        x="x"
+        y="y"
+        type="line"
+        d3Config={{ width: 600, height: 300, showAxes, margin }}
+      >
+        <Capture />
+      </Root>
+    );
+    const view = render(example());
+    const expectedDefault = showAxes
+      ? { top: 20, right: 20, bottom: 40, left: 50 }
+      : { top: 20, right: 10, bottom: 20, left: 10 };
+    const first = { top: 25, right: 30, bottom: 35, left: 90 };
+    const second = { top: 0, right: 0, bottom: 0, left: 0 };
+    for (const [margin, expected] of [
+      [first, first],
+      [second, second],
+      [undefined, expectedDefault],
+      [first, first],
+    ] as const) {
+      view.rerender(example(margin));
+      const { dimensions } = context.chartStore.getState();
+      expect(dimensions.margin).toEqual(expected);
+      expect(dimensions.innerWidth).toBe(600 - expected.left - expected.right);
+      expect(dimensions.innerHeight).toBe(300 - expected.top - expected.bottom);
+    }
+  },
+);
+
+it("restores current axes defaults when an initial override is removed", () => {
+  let context!: ContextValue;
+  function Capture() {
+    context = useChartContext();
+    return null;
+  }
+  const example = (config: Config) => (
+    <Root data={rows} d3Config={config}>
+      <Capture />
+    </Root>
+  );
+  const view = render(
+    example({ margin: { top: 30, right: 30, bottom: 30, left: 90 } }),
+  );
+  view.rerender(example({ showAxes: false }));
+  expect(context.chartStore.getState().dimensions.margin).toEqual({
+    top: 20,
+    right: 10,
+    bottom: 20,
+    left: 10,
+  });
+});

--- a/components/Chart/subcomponents/Root/Root.margin.test.tsx
+++ b/components/Chart/subcomponents/Root/Root.margin.test.tsx
@@ -1,9 +1,15 @@
 import { render } from "@testing-library/react";
-import { expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 
 import { useChartContext } from "../../context";
 import type { Config, ContextValue } from "../../types";
 import { Root } from "./Root";
+
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(600);
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(300);
+});
+afterEach(() => vi.restoreAllMocks());
 
 const rows = [
   { x: 0, y: 10 },

--- a/components/Chart/subcomponents/Root/Root.margin.test.tsx
+++ b/components/Chart/subcomponents/Root/Root.margin.test.tsx
@@ -20,11 +20,11 @@ it.each([true, false])(
     }
     const example = (margin?: Config["margin"]) => (
       <Root
+        d3Config={{ width: 600, height: 300, showAxes, margin }}
         data={rows}
+        type="line"
         x="x"
         y="y"
-        type="line"
-        d3Config={{ width: 600, height: 300, showAxes, margin }}
       >
         <Capture />
       </Root>
@@ -57,7 +57,7 @@ it("restores current axes defaults when an initial override is removed", () => {
     return null;
   }
   const example = (config: Config) => (
-    <Root data={rows} d3Config={config}>
+    <Root d3Config={config} data={rows}>
       <Capture />
     </Root>
   );

--- a/components/Chart/subcomponents/Root/Root.tsx
+++ b/components/Chart/subcomponents/Root/Root.tsx
@@ -23,6 +23,7 @@ import {
   updateChartMargin,
   updateChartState,
 } from "../../state/store/chart.store";
+import { getDimensionsInitialState } from "../../state/store/slices/dimensions.slice";
 import {
   Behavior,
   Config,
@@ -475,10 +476,14 @@ export function Root<T>({
   const marginSyncRef = useRef<string | null>(null);
   useEffect(() => {
     const configured = d3Config?.margin;
-    if (!configured) {
-      return;
-    }
-    const signature = JSON.stringify(configured);
+    const signature = configured
+      ? JSON.stringify([
+          configured.top,
+          configured.right,
+          configured.bottom,
+          configured.left,
+        ])
+      : "default";
     if (marginSyncRef.current === signature) {
       return;
     }
@@ -487,7 +492,12 @@ export function Root<T>({
     if (isFirstRun) {
       return;
     }
-    updateChartMargin(chartStore, configured);
+    updateChartMargin(
+      chartStore,
+      configured ??
+        getDimensionsInitialState({ showAxes: d3Config?.showAxes }).dimensions
+          .margin,
+    );
   });
 
   const accessorSyncRef = useRef<string | null>(null);

--- a/tests/browser/Chart/reactive-config.test.tsx
+++ b/tests/browser/Chart/reactive-config.test.tsx
@@ -36,13 +36,13 @@ it.each(["configuration", "responsive width"])(
     const example = (width: number, label: string) => (
       <DesignSystemProvider>
         <Chart
+          behaviors={[behavior]}
+          d3Config={{ yAxisLabel: label }}
           data={rows}
+          style={{ width, height: 360 }}
+          type="line"
           x="x"
           y="y"
-          type="line"
-          behaviors={[behavior]}
-          style={{ width, height: 360 }}
-          d3Config={{ yAxisLabel: label }}
         >
           <Chart.Plot>
             <Chart.Series />
@@ -85,12 +85,12 @@ it.each([true, false])(
     const example = (margin?: Config["margin"]) => (
       <DesignSystemProvider>
         <Chart
+          d3Config={{ showAxes, margin }}
           data={rows}
+          style={{ width: 700, height: 360 }}
+          type="line"
           x="x"
           y="y"
-          type="line"
-          style={{ width: 700, height: 360 }}
-          d3Config={{ showAxes, margin }}
         >
           <Chart.Plot>
             <Chart.Series />
@@ -138,12 +138,12 @@ it("restores axis-free SVG margins after removing an initial override", async ()
   const example = (margin?: Config["margin"]) => (
     <DesignSystemProvider>
       <Chart
+        d3Config={{ showAxes: false, margin }}
         data={rows}
+        style={{ width: 700, height: 360 }}
+        type="line"
         x="x"
         y="y"
-        type="line"
-        style={{ width: 700, height: 360 }}
-        d3Config={{ showAxes: false, margin }}
       >
         <Chart.Plot>
           <Chart.Series />

--- a/tests/browser/Chart/reactive-config.test.tsx
+++ b/tests/browser/Chart/reactive-config.test.tsx
@@ -1,0 +1,166 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+
+import { Chart } from "../../../components/Chart/Chart";
+import type { Config } from "../../../components/Chart/types";
+import type {
+  Behavior,
+  BehaviorContext,
+} from "../../../components/Chart/types/events";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+afterEach(cleanup);
+const rows = [
+  { x: 0, y: 10 },
+  { x: 1, y: 20 },
+];
+
+it.each(["configuration", "responsive width"])(
+  "keeps an active behavior current after changing %s",
+  async (change) => {
+    let read!: () => ReturnType<BehaviorContext["getChartContext"]>;
+    let setups = 0;
+    let cleanups = 0;
+    let advance!: () => number;
+    const behavior: Behavior = (context) => {
+      setups++;
+      let count = 0;
+      advance = () => ++count;
+      read = context.getChartContext;
+      return () => {
+        cleanups++;
+      };
+    };
+    const example = (width: number, label: string) => (
+      <DesignSystemProvider>
+        <Chart
+          data={rows}
+          x="x"
+          y="y"
+          type="line"
+          behaviors={[behavior]}
+          style={{ width, height: 360 }}
+          d3Config={{ yAxisLabel: label }}
+        >
+          <Chart.Plot>
+            <Chart.Series />
+          </Chart.Plot>
+        </Chart>
+      </DesignSystemProvider>
+    );
+    const view = render(example(700, "Before"));
+    await waitFor(() => expect(read).toBeDefined());
+    const initialRead = read;
+    const initialAdvance = advance;
+    const initialSetups = setups;
+    const initialCleanups = cleanups;
+    expect(advance()).toBe(1);
+    const root = view.container.querySelector("[data-chart-container]")!;
+    expect(root.getBoundingClientRect().width).toBe(700);
+    expect(read().isMobile).toBe(false);
+    view.rerender(example(change === "responsive width" ? 300 : 700, "After"));
+    if (change === "responsive width") {
+      await waitFor(() => expect(root.getBoundingClientRect().width).toBe(300));
+      await waitFor(() => expect(read().isMobile).toBe(true));
+      view.rerender(example(700, "After"));
+      await waitFor(() => expect(read().isMobile).toBe(false));
+    } else {
+      await waitFor(() => expect(read().config.yAxisLabel).toBe("After"));
+    }
+    expect(read).toBe(initialRead);
+    expect(advance).toBe(initialAdvance);
+    expect(advance()).toBe(2);
+    expect(setups).toBe(initialSetups);
+    expect(cleanups).toBe(initialCleanups);
+    view.unmount();
+    expect(cleanups).toBe(initialCleanups + 1);
+  },
+);
+
+it.each([true, false])(
+  "updates SVG layout when margins are added, changed, removed and reapplied (axes=%s)",
+  async (showAxes) => {
+    const example = (margin?: Config["margin"]) => (
+      <DesignSystemProvider>
+        <Chart
+          data={rows}
+          x="x"
+          y="y"
+          type="line"
+          style={{ width: 700, height: 360 }}
+          d3Config={{ showAxes, margin }}
+        >
+          <Chart.Plot>
+            <Chart.Series />
+          </Chart.Plot>
+        </Chart>
+      </DesignSystemProvider>
+    );
+    const view = render(example());
+    const svg =
+      view.container.querySelector<SVGSVGElement>("[data-chart-plot]")!;
+    const plot = view.container.querySelector<SVGGElement>(
+      "[data-chart-inner-plot]",
+    )!;
+    const rect = plot.querySelector("rect")!;
+    await waitFor(() => expect(svg.width.baseVal.value).toBeGreaterThan(500));
+    const first = { top: 25, right: 30, bottom: 35, left: 90 };
+    const second = { top: 0, right: 0, bottom: 0, left: 0 };
+    const defaults = showAxes
+      ? { top: 20, right: 20, bottom: 40, left: 50 }
+      : { top: 20, right: 10, bottom: 20, left: 10 };
+    for (const [margin, expected] of [
+      [first, first],
+      [second, second],
+      [undefined, defaults],
+      [first, first],
+    ] as const) {
+      view.rerender(example(margin));
+      await waitFor(() => {
+        const origin = new DOMPoint(0, 0).matrixTransform(plot.getScreenCTM()!);
+        const bounds = svg.getBoundingClientRect();
+        expect(origin.x - bounds.left).toBeCloseTo(expected.left);
+        expect(origin.y - bounds.top).toBeCloseTo(expected.top);
+        expect(rect.width.baseVal.value).toBeCloseTo(
+          bounds.width - expected.left - expected.right,
+        );
+        expect(rect.height.baseVal.value).toBeCloseTo(
+          bounds.height - expected.top - expected.bottom,
+        );
+      });
+    }
+  },
+);
+
+it("restores axis-free SVG margins after removing an initial override", async () => {
+  const example = (margin?: Config["margin"]) => (
+    <DesignSystemProvider>
+      <Chart
+        data={rows}
+        x="x"
+        y="y"
+        type="line"
+        style={{ width: 700, height: 360 }}
+        d3Config={{ showAxes: false, margin }}
+      >
+        <Chart.Plot>
+          <Chart.Series />
+        </Chart.Plot>
+      </Chart>
+    </DesignSystemProvider>
+  );
+  const view = render(example({ top: 25, right: 30, bottom: 35, left: 90 }));
+  const plot = view.container.querySelector<SVGGElement>(
+    "[data-chart-inner-plot]",
+  )!;
+  await waitFor(() =>
+    expect(plot.transform.baseVal.getItem(0).matrix.e).toBe(90),
+  );
+  view.rerender(example());
+  await waitFor(() => {
+    expect(plot.transform.baseVal.getItem(0).matrix.e).toBe(10);
+    expect(plot.transform.baseVal.getItem(0).matrix.f).toBe(20);
+  });
+});


### PR DESCRIPTION
Custom behaviors could read initial configuration after rerenders, and adding/removing margin overrides did not reliably update layout. Behavior getters now read committed current context while keeping active closure state; margin overrides synchronize through their full lifecycle.

Closes #88.

Validation: Red: four unit and four browser regressions failed before the fix. Green: 332 Chart unit tests and 99 Chromium browser tests; production and scoped test compilation passed.

Added source comments were reviewed for necessity. Combined verification with all nine fixes passed: 1,028 unit tests, 554 Chart checks across Chromium/Firefox/WebKit, 219 all-component Chromium checks, full typecheck, production build, four package tests, and 235 Storybook tests.
