### PR TITLE
Chart: preserve custom-series accessors during registration

### DIFF
--- a/components/Chart/state/store/chart.store.ts
+++ b/components/Chart/state/store/chart.store.ts
@@ -31,6 +31,7 @@ import {
   combineSeries,
   getSeriesInitialState,
   hydrateSeries,
+  SeriesRegistration,
   SeriesSlice,
 } from "./slices/series.slice";
 
@@ -276,7 +277,11 @@ export const updateChartAccessors = <T>(
  * Registers a series id and its configurations.
  * Often called by the `<Series />` component or sub-series layers.
  */
-export const registerSeries = (store: Store, id: string, configs: any[]) => {
+export const registerSeries = (
+  store: Store,
+  id: string,
+  configs: SeriesRegistration[],
+) => {
   store.setState((state) => {
     const nextSeries = new Map(state.series);
     const nextConfigs = new Map(state.seriesConfigs); // Clone configs map

--- a/components/Chart/state/store/slices/series.slice.ts
+++ b/components/Chart/state/store/slices/series.slice.ts
@@ -3,9 +3,28 @@ import { LinearStrategy } from "../../../sensors/utils/strategies/LinearStrategy
 import { QuadtreeStrategy } from "../../../sensors/utils/strategies/QuadtreeStrategy/index";
 import { Series } from "../../../types";
 
+export interface SeriesRegistration extends Partial<
+  Pick<
+    Series,
+    | "id"
+    | "label"
+    | "color"
+    | "data"
+    | "hideCursor"
+    | "interactionMode"
+    | "type"
+    | "orientation"
+    | "barWidth"
+    | "stackId"
+  >
+> {
+  x?: Series["xAccessor"];
+  y?: Series["yAccessor"];
+}
+
 export interface SeriesSlice {
   series: Map<string, Series[]>;
-  seriesConfigs: Map<string, any[]>;
+  seriesConfigs: Map<string, SeriesRegistration[]>;
   processedSeries: Series[];
 }
 
@@ -31,9 +50,9 @@ export const SERIES_PALETTE = [
 ];
 
 export const hydrateSeries = (
-  props: any,
+  props: SeriesRegistration,
   index: number,
-  defaultData: any[],
+  defaultData: unknown[],
 ): Series => {
   const data = props.data || defaultData;
 
@@ -41,8 +60,8 @@ export const hydrateSeries = (
     id: props.id || `series-${index}`,
     label: props.label || `Series ${index + 1}`,
     color: props.color || SERIES_PALETTE[index % SERIES_PALETTE.length],
-    xAccessor: props.x as any,
-    yAccessor: props.y as any,
+    xAccessor: props.x,
+    yAccessor: props.y,
     hideCursor: props.hideCursor,
     interactionMode: props.interactionMode,
     type: props.type,

--- a/components/Chart/subcomponents/CustomSeries/CustomSeries.registration.test.tsx
+++ b/components/Chart/subcomponents/CustomSeries/CustomSeries.registration.test.tsx
@@ -1,0 +1,126 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ChartContext } from "../../context";
+import { Engine } from "../../engine";
+import {
+  createChartStore,
+  updateChartData,
+  updateChartDimensions,
+  updateChartState,
+  upsertInteraction,
+} from "../../state/store/chart.store";
+import {
+  ContextValue,
+  HoverInteraction,
+  InteractionChannel,
+  SeriesProps,
+} from "../../types";
+import { CustomSeries } from "./CustomSeries";
+
+afterEach(cleanup);
+
+const initial = [{ rootX: 80, rootY: 90, localX: 20, localY: 30 }];
+const updated = [{ rootX: 70, rootY: 80, localX: 40, localY: 60 }];
+type Row = (typeof initial)[number];
+
+describe("CustomSeries real-store registration", () => {
+  it.each(["key", "function"] as const)(
+    "preserves %s accessors through mount and local/root data updates",
+    (kind) => {
+      const store = createChartStore({}, "rootX", "rootY");
+      updateChartState(store, {
+        data: initial,
+        xDomain: [0, 100],
+        yDomain: [0, 100],
+        dimensions: {
+          width: 120,
+          height: 120,
+          innerWidth: 100,
+          innerHeight: 100,
+          margin: { top: 10, left: 10, bottom: 10, right: 10 },
+        },
+      });
+      const context: ContextValue<Row> = {
+        chartStore: store,
+        engine: new Engine<Row>(),
+        config: {},
+        isMobile: false,
+        colorPalette: [],
+        styles: {},
+        resolveInteraction: () => null,
+        x: "rootX",
+        y: "rootY",
+      };
+      const accessors: Pick<SeriesProps<Row>, "x" | "y"> = kind === "key"
+        ? { x: "localX", y: "localY" }
+        : { x: (row) => row.localX, y: (row) => row.localY };
+      const tree = (data?: Row[]) => (
+        <ChartContext.Provider value={context}>
+          <svg>
+            <CustomSeries {...accessors} data={data} label="Custom" />
+          </svg>
+        </ChartContext.Provider>
+      );
+      const view = render(tree(initial));
+      const series = store.getState().processedSeries[0];
+      const scales = store.getState().scales;
+      expect(
+        series.strategy!.find(20, 70, 1, scales.x!, scales.y!),
+      ).toMatchObject({ data: initial[0], coordinate: { x: 20, y: 70 } });
+      const hover: HoverInteraction<Row> = {
+        pointer: {
+          x: 20,
+          y: 70,
+          containerX: 30,
+          containerY: 80,
+          isTouch: false,
+        },
+        targets: [
+          {
+            seriesId: series.id,
+            dataIndex: 0,
+            data: initial[0],
+            coordinate: { x: 30, y: 80 },
+          },
+        ],
+      };
+      const target = () =>
+        (
+          store
+            .getState()
+            .interactions.get(
+              InteractionChannel.PRIMARY_HOVER,
+            ) as HoverInteraction<Row>
+        ).targets[0];
+      act(() => {
+        upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, hover);
+        updateChartDimensions(store, 120, 120);
+      });
+      expect(target()).toMatchObject({
+        data: initial[0],
+        coordinate: { x: 30, y: 80 },
+      });
+      view.rerender(tree(updated));
+      expect(target()).toMatchObject({
+        data: updated[0],
+        coordinate: { x: 50, y: 50 },
+      });
+      act(() => updateChartData(store, [{ ...initial[0], rootY: 50 }]));
+      expect(target()).toMatchObject({
+        data: updated[0],
+        coordinate: { x: 50, y: 50 },
+      });
+      view.rerender(tree());
+      act(() => updateChartData(store, updated));
+      expect(target()).toMatchObject({
+        data: updated[0],
+        coordinate: { x: 50, y: 50 },
+      });
+      view.unmount();
+      expect(store.getState().processedSeries).toHaveLength(0);
+      expect(store.getState().seriesConfigs.size).toBe(0);
+      context.engine.dispose();
+    },
+  );
+});

--- a/components/Chart/subcomponents/CustomSeries/CustomSeries.tsx
+++ b/components/Chart/subcomponents/CustomSeries/CustomSeries.tsx
@@ -42,12 +42,12 @@ const CustomSeriesComponent = <T,>(props: SeriesProps<T>) => {
         label: effectiveLabel,
         color,
         data: localData,
-        yAccessor,
-        xAccessor,
+        y: yAccessor,
+        x: xAccessor,
         hideCursor: true,
         interactionMode: "x",
         id: seriesId,
-      } as any,
+      },
     ]);
 
     return () => {

--- a/components/Chart/subcomponents/CustomSeries/CustomSeries.types.test.ts
+++ b/components/Chart/subcomponents/CustomSeries/CustomSeries.types.test.ts
@@ -1,0 +1,16 @@
+import { expectTypeOf, it } from "vitest";
+
+import { registerSeries } from "../../state/store/chart.store";
+
+it("accepts registration accessors only under x and y", () => {
+  type Registration = Parameters<typeof registerSeries>[2][number];
+  expectTypeOf<Registration>().not.toBeAny();
+  expectTypeOf<{ x: "time"; y: "value" }>().toExtend<Registration>();
+  // Hydration reads x/y; accepting the output field names loses accessors.
+  // @ts-expect-error xAccessor is a hydrated field, not a registration input.
+  const invalidX: Registration = { xAccessor: "time" };
+  // @ts-expect-error yAccessor is a hydrated field, not a registration input.
+  const invalidY: Registration = { yAccessor: "value" };
+  void invalidX;
+  void invalidY;
+});

--- a/tests/browser/Chart/custom-accessors.test.tsx
+++ b/tests/browser/Chart/custom-accessors.test.tsx
@@ -1,0 +1,118 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { useChartContext } from "../../../components/Chart/context";
+import { Store } from "../../../components/Chart/state/store/chart.store";
+import {
+  HoverInteraction,
+  InteractionChannel,
+  RenderFrame,
+} from "../../../components/Chart/types";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+afterEach(cleanup);
+
+const root = [
+  { x: 80, y: 10 },
+  { x: 20, y: 90 },
+];
+const initial = [
+  { time: 20, value: 30 },
+  { time: 80, value: 50 },
+];
+const updated = [
+  { time: 20, value: 60 },
+  { time: 80, value: 40 },
+];
+type Row = (typeof initial)[number];
+
+function draw({
+  container,
+  data,
+  scales,
+  chartDataAttrs,
+  seriesId,
+}: RenderFrame<Row>) {
+  container
+    .selectAll<SVGCircleElement, Row>("circle")
+    .data(data)
+    .join("circle")
+    .attr("data-custom-point", "true")
+    .attr(chartDataAttrs.TYPE, "data-point")
+    .attr(chartDataAttrs.SERIES_ID, seriesId)
+    .attr(chartDataAttrs.INDEX, (_, index) => index)
+    .attr("cx", (row) => (scales.x as (value: number) => number)(row.time))
+    .attr("cy", (row) => (scales.y as (value: number) => number)(row.value))
+    .attr("r", 8);
+}
+
+it("keeps custom coordinates and multi-series tooltips after data and layout updates", async () => {
+  let store: Store;
+  function Probe() {
+    store = useChartContext().chartStore;
+    return null;
+  }
+  const tree = (data: Row[], width: number) => (
+    <DesignSystemProvider>
+      <Chart
+        data={root}
+        style={{ width, height: 400 }}
+        x="x"
+        xDomain={[0, 100]}
+        y="y"
+        yDomain={[0, 100]}
+      >
+        <Chart.Plot>
+          <Chart.Series
+            data={data}
+            label="Custom"
+            render={draw}
+            x="time"
+            y={(row) => row.value}
+          />
+          <Chart.Series label="Root" type="line" />
+          <Probe />
+        </Chart.Plot>
+      </Chart>
+    </DesignSystemProvider>
+  );
+  const view = render(tree(initial, 650));
+  const mark = () =>
+    view.container.querySelector<SVGCircleElement>("[data-custom-point]")!;
+  const tooltip = () =>
+    view.container.querySelector("[data-chart-tooltip]")?.textContent;
+  await expect
+    .poll(() => mark()?.getBoundingClientRect().width)
+    .toBeGreaterThan(0);
+  await userEvent.hover(mark());
+  await expect
+    .poll(tooltip)
+    .toMatch(/^20(?:Custom:30Root:90|Root:90Custom:30)$/);
+  view.rerender(tree(updated, 750));
+  await expect
+    .poll(tooltip)
+    .toMatch(/^20(?:Custom:60Root:90|Root:90Custom:60)$/);
+  await expect
+    .poll(() => {
+      const state = store.getState();
+      const hover = state.interactions.get(
+        InteractionChannel.PRIMARY_HOVER,
+      ) as HoverInteraction;
+      const target = hover?.targets.find(
+        (item) => item.seriesId === mark().getAttribute("data-chart-series"),
+      );
+      return target?.coordinate;
+    })
+    .toEqual({
+      x:
+        Number(mark().getAttribute("cx")) +
+        store!.getState().dimensions.margin.left,
+      y:
+        Number(mark().getAttribute("cy")) +
+        store!.getState().dimensions.margin.top,
+    });
+});


### PR DESCRIPTION
Custom series registered accessor fields that hydration did not read. Registration now preserves local x/y accessors through data updates and uses a typed input contract.

Closes #89.

Validation: Red: real-store, browser tooltip, and compiler-contract regressions reproduced accessor loss. Green: 331 Chart unit tests, 13 focused Chromium browser tests, production build, and scoped compilation.

Added source comments were reviewed for necessity. Combined verification with all nine fixes passed: 1,028 unit tests, 554 Chart checks across Chromium/Firefox/WebKit, 219 all-component Chromium checks, full typecheck, production build, four package tests, and 235 Storybook tests.
