### PR TITLE
Chart: honor reduced motion in active series styles

### DIFF
--- a/components/Chart/reducedMotion.test.ts
+++ b/components/Chart/reducedMotion.test.ts
@@ -12,7 +12,12 @@ it("ships reduced-motion rules scoped to chart plots", () => {
       return;
     }
     media.walkDecls("transition", (declaration) => {
-      if (declaration.value === "none" && declaration.parent?.type === "rule") {
+      if (
+        declaration.value === "none" &&
+        declaration.parent &&
+        "selector" in declaration.parent &&
+        typeof declaration.parent.selector === "string"
+      ) {
         selectors.push(declaration.parent.selector);
       }
     });

--- a/components/Chart/reducedMotion.test.ts
+++ b/components/Chart/reducedMotion.test.ts
@@ -1,0 +1,28 @@
+import postcss from "postcss";
+import { compile } from "sass";
+import { expect, it } from "vitest";
+
+it("ships reduced-motion rules scoped to chart plots", () => {
+  const sheet = postcss.parse(
+    compile("components/Chart/subcomponents/Root/Root.module.scss").css,
+  );
+  const selectors: string[] = [];
+  sheet.walkAtRules("media", (media) => {
+    if (media.params !== "(prefers-reduced-motion: reduce)") {
+      return;
+    }
+    media.walkDecls("transition", (declaration) => {
+      if (declaration.value === "none" && declaration.parent?.type === "rule") {
+        selectors.push(declaration.parent.selector);
+      }
+    });
+  });
+  expect(selectors.length).toBeGreaterThan(0);
+  expect(
+    selectors.every(
+      (selector) =>
+        selector.includes(".chartContainer") &&
+        selector.includes("data-chart-plot"),
+    ),
+  ).toBe(true);
+});

--- a/components/Chart/subcomponents/Root/Root.module.scss
+++ b/components/Chart/subcomponents/Root/Root.module.scss
@@ -36,8 +36,16 @@
       --chart-series-2: var(--solid-success);
       --chart-series-3: var(--solid-warning);
       --chart-series-4: var(--solid-error);
-      --chart-series-5: color-mix(in srgb, var(--solid-fg) 65%, var(--solid-bg));
-      --chart-series-6: color-mix(in srgb, var(--solid-fg) 40%, var(--solid-bg));
+      --chart-series-5: color-mix(
+        in srgb,
+        var(--solid-fg) 65%,
+        var(--solid-bg)
+      );
+      --chart-series-6: color-mix(
+        in srgb,
+        var(--solid-fg) 40%,
+        var(--solid-bg)
+      );
 
       :global(.tick) text {
         fill: var(--solid-fg);
@@ -60,5 +68,14 @@
     min-height: 0;
     position: relative;
     overflow: visible;
+  }
+}
+
+@layer doom.components {
+  @media (prefers-reduced-motion: reduce) {
+    .chartContainer :global([data-chart-plot]) * {
+      transition: none !important;
+      animation: none !important;
+    }
   }
 }

--- a/tests/browser/Chart/reduced-motion.test.tsx
+++ b/tests/browser/Chart/reduced-motion.test.tsx
@@ -1,0 +1,62 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, expect, it } from "vitest";
+import { commands, userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+
+declare module "vitest/browser" {
+  interface BrowserCommands {
+    setReducedMotion(preference: "reduce" | "no-preference"): Promise<void>;
+  }
+}
+
+afterEach(async () => {
+  cleanup();
+  await commands.setReducedMotion("no-preference");
+});
+
+it.each(["line", "scatter", "bar"] as const)(
+  "%s marks respect changes to reduced-motion preference",
+  async (type) => {
+    await commands.setReducedMotion("no-preference");
+    const { container } = render(
+      <Chart
+        d3Config={{ showDots: true }}
+        data={[
+          { x: "Jan", y: 10 },
+          { x: "Feb", y: 20 },
+          { x: "Mar", y: 15 },
+        ]}
+        style={{ width: 700, height: 360 }}
+        type={type}
+        x="x"
+        y="y"
+      />,
+    );
+    const selector = type === "bar" ? '[data-chart-type="bar"]' : "circle";
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll(selector).length,
+      ).toBeGreaterThanOrEqual(3),
+    );
+    const marks = container.querySelectorAll(selector);
+    expect(getComputedStyle(marks[1]).transitionDuration).not.toBe("0s");
+    await commands.setReducedMotion("reduce");
+    expect(matchMedia("(prefers-reduced-motion: reduce)").matches).toBe(true);
+    await userEvent.hover(marks[1]);
+    await waitFor(() =>
+      expect(
+        container.querySelector("[data-chart-tooltip]")?.textContent,
+      ).toContain("Feb"),
+    );
+    for (const mark of marks) {
+      expect(getComputedStyle(mark).transitionDuration).toBe("0s");
+      expect(mark.getAnimations()).toHaveLength(0);
+    }
+    await commands.setReducedMotion("no-preference");
+    expect(getComputedStyle(marks[1]).transitionDuration).not.toBe("0s");
+  },
+);

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
       enabled: true,
       provider: playwright(),
       headless: true,
+      commands: {
+        async setReducedMotion(
+          { page },
+          preference: "reduce" | "no-preference",
+        ) {
+          await page.emulateMedia({ reducedMotion: preference });
+        },
+      },
       screenshotFailures: false,
       // A desktop viewport by default: the runner's own window is narrow
       // enough to read as mobile, which would mask any container-vs-viewport


### PR DESCRIPTION
Chart transitions continued under reduced-motion preferences because the existing override was not in active styles. The shipped root stylesheet now disables plot transitions and animations under reduced motion.

Closes #93.

Validation: Red: the compiled-style unit test and all three native-browser motion regressions failed before the fix. Green: 329 Chart unit tests, three browser regressions covering line/scatter/bar, and production build.

Added source comments were reviewed for necessity. Combined verification with all nine fixes passed: 1,028 unit tests, 554 Chart checks across Chromium/Firefox/WebKit, 219 all-component Chromium checks, full typecheck, production build, four package tests, and 235 Storybook tests.
