### PR TITLE
Chart: map pointer coordinates correctly through scaled containers

### DIFF
--- a/components/Chart/engine/CoordinateSystem.test.ts
+++ b/components/Chart/engine/CoordinateSystem.test.ts
@@ -96,3 +96,57 @@ describe("viewport to chart coordinates", () => {
     expect(coords.resolvePointerCoordinates(50, 80)).toEqual({ x: 40, y: 60 });
   });
 });
+
+it.each([
+  ["border-box", 1],
+  ["content-box", 1],
+  ["border-box", 0.75],
+  ["content-box", 0.75],
+] as const)(
+  "preserves exact fractional plot boundaries with %s at scale %s",
+  (boxSizing, scale) => {
+    const container = document.createElement("div");
+    container.style.cssText = `box-sizing: ${boxSizing}; width: ${boxSizing === "border-box" ? 600.25 : 568.75}px; height: ${boxSizing === "border-box" ? 300.25 : 276.75}px; padding: 8.25px 12.25px; border: 3px solid; border-right-width: 4px; border-bottom-width: 4px`;
+    document.body.append(container);
+    Object.defineProperties(container, {
+      offsetWidth: { value: 600 },
+      offsetHeight: { value: 300 },
+    });
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(100, 200, 600.25 * scale, 300.25 * scale),
+    );
+    const coords = new CoordinateSystem();
+    coords.setContainer(container, null, {
+      x: 40,
+      y: 20,
+      width: 500,
+      height: 200,
+    });
+    const resolve = (x: number, y: number) => {
+      const point = coords.resolvePointerCoordinates(
+        100 + x * scale,
+        200 + y * scale,
+      )!;
+      const offset = coords.getPlotOffset();
+      return coords.resolveChartCoordinates(
+        point.x - offset.x,
+        point.y - offset.y,
+      );
+    };
+    expect(resolve(55.25, 31.25)).toEqual({
+      chartX: 0,
+      chartY: 0,
+      isWithinPlot: true,
+    });
+    expect(resolve(555.25, 231.25)).toEqual({
+      chartX: 500,
+      chartY: 200,
+      isWithinPlot: true,
+    });
+    expect(resolve(55.125, 31.25)).toEqual({
+      chartX: -0.125,
+      chartY: 0,
+      isWithinPlot: false,
+    });
+  },
+);

--- a/components/Chart/engine/CoordinateSystem.test.ts
+++ b/components/Chart/engine/CoordinateSystem.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CoordinateSystem } from "./CoordinateSystem";
+
+const bounds = { x: 40, y: 20, width: 500, height: 200 };
+
+function fixture(scaleX = 0.75, scaleY = scaleX) {
+  const container = document.createElement("div");
+  const plot = document.createElement("div");
+  container.style.cssText =
+    "border-left: 4px solid; border-top: 6px solid; padding: 12px";
+  container.append(plot);
+  document.body.append(container);
+  let left = 100;
+  let top = 200;
+  let width = 800;
+  let plotTop = 66;
+  Object.defineProperties(container, {
+    offsetWidth: { get: () => width },
+    offsetHeight: { get: () => 400 },
+  });
+  vi.spyOn(container, "getBoundingClientRect").mockImplementation(
+    () => new DOMRect(left, top, width * scaleX, 400 * scaleY),
+  );
+  vi.spyOn(plot, "getBoundingClientRect").mockImplementation(
+    () =>
+      new DOMRect(
+        left + 16 * scaleX,
+        top + plotTop * scaleY,
+        (width - 32) * scaleX,
+        300 * scaleY,
+      ),
+  );
+  const coords = new CoordinateSystem();
+  coords.setContainer(container, plot, bounds);
+  return {
+    coords,
+    move: () => {
+      left = 20;
+      top = -100;
+    },
+    resize: () => {
+      width = 1000;
+      scaleX = 1.25;
+      scaleY = 0.5;
+      plotTop = 86;
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("viewport to chart coordinates", () => {
+  it.each([
+    [0.75, 0.75],
+    [1.25, 0.5],
+    [1, 1],
+  ])(
+    "maps scale(%s, %s), borders and header offsets to local pixels",
+    (sx, sy) => {
+      const { coords } = fixture(sx, sy);
+      const point = coords.resolvePointerCoordinates(
+        100 + 256 * sx,
+        200 + 146 * sy,
+      )!;
+      expect(point).toEqual({ x: 252, y: 140 });
+      const offset = coords.getPlotOffset();
+      expect(offset).toEqual({ x: 12, y: 60 });
+      expect(
+        coords.resolveChartCoordinates(point.x - offset.x, point.y - offset.y),
+      ).toEqual({ chartX: 200, chartY: 60, isWithinPlot: true });
+    },
+  );
+
+  it("refreshes viewport geometry after scrolling, resizing and header layout changes", () => {
+    const { coords, move, resize } = fixture();
+    move();
+    expect(coords.resolvePointerCoordinates(212, 9.5)).toEqual({
+      x: 252,
+      y: 140,
+    });
+    resize();
+    expect(coords.resolvePointerCoordinates(340, -17)).toEqual({
+      x: 252,
+      y: 160,
+    });
+    expect(coords.getPlotOffset()).toEqual({ x: 12, y: 80 });
+  });
+
+  it("retains explicit-rectangle input without a mounted element", () => {
+    const coords = new CoordinateSystem();
+    coords.updateBounds(new DOMRect(10, 20, 800, 400));
+    expect(coords.resolvePointerCoordinates(50, 80)).toEqual({ x: 40, y: 60 });
+  });
+});

--- a/components/Chart/engine/CoordinateSystem.ts
+++ b/components/Chart/engine/CoordinateSystem.ts
@@ -1,3 +1,5 @@
+import { getElementScale } from "../utils/elementScale";
+
 export interface ContainerStyle {
   borderLeft: number;
   borderTop: number;
@@ -24,7 +26,7 @@ export interface ChartCoordinates {
  * Handles the complexity of mapping screen coordinates (ClientX/Y)
  * to Chart coordinates (PlotX/Y), accounting for:
  * - Container position (getBoundingClientRect)
- * - CSS Borders and Padding
+ * - CSS scaling, borders and padding
  * - Layout offsets (e.g. Headers pushing the plot down)
  */
 export class CoordinateSystem {
@@ -107,9 +109,14 @@ export class CoordinateSystem {
     }
 
     const plotRect = this.plotElement.getBoundingClientRect();
+    const scale = getElementScale(this.containerElement, containerRect);
     return {
-      x: plotRect.left - containerRect.left - this.containerStyle.borderLeft,
-      y: plotRect.top - containerRect.top - this.containerStyle.borderTop,
+      x:
+        (plotRect.left - containerRect.left) / scale.x -
+        this.containerStyle.borderLeft,
+      y:
+        (plotRect.top - containerRect.top) / scale.y -
+        this.containerStyle.borderTop,
     };
   }
 
@@ -148,9 +155,13 @@ export class CoordinateSystem {
       return null;
     }
 
+    const scale = getElementScale(this.containerElement, rect);
+    this.containerRect = rect;
+    this.plotOffset = this.measurePlotOffset(rect);
+
     return {
-      x: clientX - rect.left - this.containerStyle.borderLeft,
-      y: clientY - rect.top - this.containerStyle.borderTop,
+      x: (clientX - rect.left) / scale.x - this.containerStyle.borderLeft,
+      y: (clientY - rect.top) / scale.y - this.containerStyle.borderTop,
     };
   }
 

--- a/components/Chart/engine/SpatialMap.dom.test.ts
+++ b/components/Chart/engine/SpatialMap.dom.test.ts
@@ -305,3 +305,44 @@ describe("SpatialMap DOM Hit Testing", () => {
     expect(domCandidate).toBeUndefined();
   });
 });
+
+it("maps scaled padding-box coordinates to DOM hits and local distances", () => {
+  const map = new SpatialMap();
+  const container = document.createElement("div");
+  container.style.cssText = "border-left: 4px solid; border-top: 6px solid";
+  document.body.append(container);
+  Object.defineProperties(container, {
+    offsetWidth: { value: 800 },
+    offsetHeight: { value: 400 },
+  });
+  vi.spyOn(container, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(100, 200, 600, 200),
+  );
+  const mark = document.createElement("div");
+  mark.setAttribute(CHART_DATA_ATTRS.TYPE, "bar");
+  mark.setAttribute(CHART_DATA_ATTRS.SERIES_ID, "actual");
+  mark.setAttribute(CHART_DATA_ATTRS.INDEX, "0");
+  container.append(mark);
+  vi.spyOn(mark, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(250, 240, 30, 20),
+  );
+  const hitTest = vi
+    .spyOn(document, "elementsFromPoint")
+    .mockImplementation((x, y) =>
+      x >= 250 && x <= 280 && y >= 240 && y <= 260 ? [mark] : [],
+    );
+  const data = { value: 50 };
+  map.setContainer(container);
+  map.updateIndex([
+    { x: 1000, y: 1000, seriesId: "actual", dataIndex: 0, data },
+  ]);
+  try {
+    const candidate = map.find(0, 0, { x: 216, y: 94 })[0];
+    expect(candidate?.data).toBe(data);
+    expect(candidate?.coordinate).toEqual({ x: 216, y: 94 });
+    expect(candidate?.distance).toBe(0);
+  } finally {
+    hitTest.mockRestore();
+    container.remove();
+  }
+});

--- a/components/Chart/engine/SpatialMap.ts
+++ b/components/Chart/engine/SpatialMap.ts
@@ -7,6 +7,7 @@
 
 import { Quadtree, quadtree } from "d3-quadtree";
 
+import { getElementScale } from "../utils/elementScale";
 import { CandidateType, InteractionCandidate } from "./types";
 
 // =============================================================================
@@ -241,8 +242,12 @@ export class SpatialMap<T = unknown> {
     }
 
     const rect = this.containerElement.getBoundingClientRect();
-    const viewportX = rect.left + x;
-    const viewportY = rect.top + y;
+    const scale = getElementScale(this.containerElement, rect);
+    const style = getComputedStyle(this.containerElement);
+    const viewportX =
+      rect.left + (x + (parseFloat(style.borderLeftWidth) || 0)) * scale.x;
+    const viewportY =
+      rect.top + (y + (parseFloat(style.borderTopWidth) || 0)) * scale.y;
 
     const elements = document.elementsFromPoint(viewportX, viewportY);
     const candidates: InteractionCandidate<T>[] = [];
@@ -287,8 +292,14 @@ export class SpatialMap<T = unknown> {
       return null;
     }
 
-    const elementCenterX = rect.left + rect.width / 2 - containerRect.left;
-    const elementCenterY = rect.top + rect.height / 2 - containerRect.top;
+    const scale = getElementScale(this.containerElement, containerRect);
+    const style = getComputedStyle(this.containerElement!);
+    const elementCenterX =
+      (rect.left + rect.width / 2 - containerRect.left) / scale.x -
+      (parseFloat(style.borderLeftWidth) || 0);
+    const elementCenterY =
+      (rect.top + rect.height / 2 - containerRect.top) / scale.y -
+      (parseFloat(style.borderTopWidth) || 0);
 
     const distance = Math.hypot(
       pointerX - elementCenterX,

--- a/components/Chart/utils/elementScale.ts
+++ b/components/Chart/utils/elementScale.ts
@@ -1,7 +1,33 @@
 /** Ratios between viewport pixels and local border-box pixels, including scaled ancestors. */
 export function getElementScale(element: Element | null, rect: DOMRect) {
-  const width = element instanceof HTMLElement ? element.offsetWidth : 0;
-  const height = element instanceof HTMLElement ? element.offsetHeight : 0;
+  let width = 0;
+  let height = 0;
+  if (element instanceof HTMLElement) {
+    const style = getComputedStyle(element);
+    const pixels = (value: string) => parseFloat(value) || 0;
+    // offsetWidth/Height round away fractional layout pixels and invent a scale
+    // even on untransformed charts. Computed sizes retain that precision.
+    width = parseFloat(style.width);
+    height = parseFloat(style.height);
+    if (style.boxSizing !== "border-box") {
+      width +=
+        pixels(style.paddingLeft) +
+        pixels(style.paddingRight) +
+        pixels(style.borderLeftWidth) +
+        pixels(style.borderRightWidth);
+      height +=
+        pixels(style.paddingTop) +
+        pixels(style.paddingBottom) +
+        pixels(style.borderTopWidth) +
+        pixels(style.borderBottomWidth);
+    }
+    if (!Number.isFinite(width)) {
+      width = element.offsetWidth;
+    }
+    if (!Number.isFinite(height)) {
+      height = element.offsetHeight;
+    }
+  }
   return {
     x: width > 0 && rect.width > 0 ? rect.width / width : 1,
     y: height > 0 && rect.height > 0 ? rect.height / height : 1,

--- a/components/Chart/utils/elementScale.ts
+++ b/components/Chart/utils/elementScale.ts
@@ -1,0 +1,9 @@
+/** Ratios between viewport pixels and local border-box pixels, including scaled ancestors. */
+export function getElementScale(element: Element | null, rect: DOMRect) {
+  const width = element instanceof HTMLElement ? element.offsetWidth : 0;
+  const height = element instanceof HTMLElement ? element.offsetHeight : 0;
+  return {
+    x: width > 0 && rect.width > 0 ? rect.width / width : 1,
+    y: height > 0 && rect.height > 0 ? rect.height / height : 1,
+  };
+}

--- a/tests/browser/Chart/coordinateCommands.ts
+++ b/tests/browser/Chart/coordinateCommands.ts
@@ -1,0 +1,22 @@
+import { defineBrowserCommand } from "@vitest/browser-playwright";
+
+export const moveChartPointer = defineBrowserCommand(
+  async ({ page, frame }, clientX: number, clientY: number) => {
+    const iframe = await (await frame()).frameElement();
+    const box = await iframe.boundingBox();
+    const width = await iframe.evaluate(
+      (el) => (el as HTMLIFrameElement).clientWidth,
+    );
+    if (!box || box.width !== width) {
+      throw new Error("Exact pointer tests require an unscaled runner iframe");
+    }
+    // Locator.hover truncates positions; mouse.move retains subpixel boundaries.
+    await page.mouse.move(box.x + clientX, box.y + clientY);
+  },
+);
+
+declare module "vitest/browser" {
+  interface BrowserCommands {
+    moveChartPointer: (clientX: number, clientY: number) => Promise<void>;
+  }
+}

--- a/tests/browser/Chart/coordinates.test.tsx
+++ b/tests/browser/Chart/coordinates.test.tsx
@@ -1,0 +1,174 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+const rows = Array.from({ length: 31 }, (_, i) => ({
+  day: `January ${i + 1}`,
+  actual: 50,
+  forecast: 80,
+}));
+afterEach(cleanup);
+
+function Example({ scale = "scale(0.75)", width = 800, id = "first" }) {
+  return (
+    <div
+      data-testid={id}
+      style={{ transform: scale, transformOrigin: "top left", width }}
+    >
+      <Chart.Root
+        d3Config={{ showDots: true }}
+        data={rows}
+        style={{ width: "100%", height: 360 }}
+        type="line"
+        x="day"
+        y="actual"
+      >
+        <Chart.Header title="Daily readings" />
+        <Chart.Plot>
+          <Chart.Series label="Actual" type="line" y="actual" />
+          <Chart.Series label="Forecast" type="line" y="forecast" />
+          <Chart.Axis />
+        </Chart.Plot>
+      </Chart.Root>
+    </div>
+  );
+}
+
+async function hoverNear(root: HTMLElement, index = 20) {
+  const marks = () => root.querySelectorAll('circle[role="graphics-symbol"]');
+  await expect.poll(() => marks().length).toBe(62);
+  const mark = marks()[index];
+  await expect
+    .poll(() => mark.getBoundingClientRect().width)
+    .toBeGreaterThan(0);
+  const svg = root.querySelector("svg[data-chart-plot]")!;
+  await expect
+    .poll(() => Number(svg.getAttribute("width")))
+    .toBe(svg.parentElement!.clientWidth);
+  const rect = mark.getBoundingClientRect();
+  const svgRect = svg.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.bottom + 10;
+  // A nearby empty point exercises the spatial index instead of a direct mark hit.
+  expect(
+    document
+      .elementsFromPoint(x, y)
+      .some((el) => el.matches('circle[role="graphics-symbol"]')),
+  ).toBe(false);
+  await userEvent.hover(svg, {
+    position: { x: x - svgRect.left, y: y - svgRect.top },
+  });
+  await expect
+    .poll(() => root.querySelector("[data-chart-tooltip]")?.textContent)
+    .toBe(`January ${index + 1}Actual:50Forecast:80`);
+}
+
+it.each(["scale(0.75)", "scale(1.1, 0.8)"])(
+  "selects January 21 near its mark through %s",
+  async (scale) => {
+    const { container } = render(
+      <DesignSystemProvider>
+        <Example scale={scale} />
+      </DesignSystemProvider>,
+    );
+    await hoverNear(container);
+  },
+);
+
+it("maps native hover after ancestor scrolling and chart resizing", async () => {
+  const { container, rerender } = render(
+    <DesignSystemProvider>
+      <div
+        data-testid="scroll"
+        style={{ overflow: "auto", height: 500, width: 1000 }}
+      >
+        <div style={{ height: 150 }} />
+        <Example />
+        <div style={{ height: 600 }} />
+      </div>
+    </DesignSystemProvider>,
+  );
+  const scroller = container.querySelector('[data-testid="scroll"]')!;
+  scroller.scrollTop = 100;
+  await hoverNear(container);
+  rerender(
+    <DesignSystemProvider>
+      <div
+        data-testid="scroll"
+        style={{ overflow: "auto", height: 500, width: 1000 }}
+      >
+        <div style={{ height: 150 }} />
+        <Example scale="scale(0.9)" width={680} />
+        <div style={{ height: 600 }} />
+      </div>
+    </DesignSystemProvider>,
+  );
+  await expect
+    .poll(
+      () =>
+        container
+          .querySelector("[data-chart-container]")
+          ?.getBoundingClientRect().width,
+    )
+    .toBeCloseTo(612, 0);
+  await hoverNear(container, 23);
+});
+
+it("keeps differently scaled chart instances independent", async () => {
+  const { container } = render(
+    <DesignSystemProvider>
+      <div style={{ display: "flex", gap: 10 }}>
+        <Example width={600} />
+        <Example id="second" scale="scale(0.8)" width={600} />
+      </div>
+    </DesignSystemProvider>,
+  );
+  const first = container.querySelector<HTMLElement>('[data-testid="first"]')!;
+  const second = container.querySelector<HTMLElement>(
+    '[data-testid="second"]',
+  )!;
+  await hoverNear(first);
+  await hoverNear(second, 24);
+  await expect
+    .poll(() => first.querySelector("[data-chart-tooltip]")?.textContent ?? "")
+    .toBe("");
+});
+
+it("preserves exact DOM hits on scaled bars away from their spatial centers", async () => {
+  const sensors = [Chart.sensors.DataHoverSensor({ exactHit: true })];
+  const { container } = render(
+    <DesignSystemProvider>
+      <div style={{ transform: "scale(0.75)", transformOrigin: "top left" }}>
+        <Chart
+          data={[{ day: "January 21", value: 100 }]}
+          sensors={sensors}
+          style={{ width: 800, height: 400 }}
+          type="bar"
+          x="day"
+          y="value"
+        >
+          <Chart.Plot>
+            <Chart.Series barWidth={20} type="bar" />
+            <Chart.Axis />
+          </Chart.Plot>
+        </Chart>
+      </div>
+    </DesignSystemProvider>,
+  );
+  const bar = () => container.querySelector(".chart-bar")!;
+  await expect
+    .poll(() => bar()?.getBoundingClientRect().height ?? 0)
+    .toBeGreaterThan(100);
+  await userEvent.hover(bar(), {
+    position: { x: bar().getBoundingClientRect().width / 2, y: 20 },
+  });
+  await expect
+    .poll(() => container.querySelector("[data-chart-tooltip]")?.textContent)
+    .toContain("January 21");
+});

--- a/tests/browser/Chart/fractional-coordinates.test.tsx
+++ b/tests/browser/Chart/fractional-coordinates.test.tsx
@@ -1,0 +1,98 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, expect, it } from "vitest";
+import { commands, page } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import {
+  type EngineEvent,
+  InputAction,
+} from "../../../components/Chart/engine";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+afterEach(cleanup);
+
+it.each([
+  ["border-box", 1],
+  ["content-box", 1],
+  ["border-box", 0.75],
+  ["content-box", 0.75],
+] as const)(
+  "keeps native pointer boundaries exact for fractional %s at scale %s",
+  async (boxSizing, scale) => {
+    // Fit the runner window without its preview transform.
+    await page.viewport(1200, 700);
+    let latest: EngineEvent | undefined;
+    const observe = (event: EngineEvent) => {
+      if (event.signal.action === InputAction.MOVE) {
+        latest = event;
+      }
+    };
+    const { container } = render(
+      <DesignSystemProvider>
+        <div
+          style={{ transform: `scale(${scale})`, transformOrigin: "top left" }}
+        >
+          <Chart
+            d3Config={{ margin: { left: 40, top: 20, right: 20, bottom: 30 } }}
+            data={[
+              { x: 0, y: 0 },
+              { x: 1, y: 1 },
+            ]}
+            sensors={[observe]}
+            style={{
+              boxSizing,
+              width: 600.25,
+              height: 300.25,
+              padding: "8.25px 12.25px",
+              borderWidth: "3px 4px 4px 3px",
+            }}
+            type="line"
+            x="x"
+            y="y"
+          >
+            <Chart.Plot>
+              <Chart.Series type="line" />
+            </Chart.Plot>
+          </Chart>
+        </div>
+      </DesignSystemProvider>,
+    );
+    const svg = container.querySelector("svg[data-chart-plot]")!;
+    await expect
+      .poll(() => Number(svg.getAttribute("width")))
+      .toBeGreaterThan(500);
+    const plot = container.querySelector("[data-chart-inner-plot] > rect")!;
+    await expect
+      .poll(() => plot?.getBoundingClientRect().width ?? 0)
+      .toBeGreaterThan(400 * scale);
+    const width = Number(plot.getAttribute("width"));
+    const height = Number(plot.getAttribute("height"));
+    const rect = plot.getBoundingClientRect();
+    const hover = async (x: number, y: number) => {
+      latest = undefined;
+      await commands.moveChartPointer(
+        rect.left + x * scale,
+        rect.top + y * scale,
+      );
+      await expect.poll(() => latest).toBeDefined();
+    };
+    await hover(0, height / 2);
+    expect(latest?.chartX).toBe(0);
+    expect(latest?.isWithinPlot).toBe(true);
+    await hover(width / 2, 0);
+    expect(latest?.chartY).toBe(0);
+    expect(latest?.isWithinPlot).toBe(true);
+    await hover(width, height / 2);
+    expect(latest?.chartX).toBe(width);
+    expect(latest?.isWithinPlot).toBe(true);
+    await hover(width / 2, height);
+    expect(latest?.chartY).toBe(height);
+    expect(latest?.isWithinPlot).toBe(true);
+    await hover(-0.125, height / 2);
+    expect(latest?.chartX).toBe(-0.125);
+    expect(latest?.isWithinPlot).toBe(false);
+  },
+);

--- a/tests/browser/Chart/fractional-coordinates.test.tsx
+++ b/tests/browser/Chart/fractional-coordinates.test.tsx
@@ -3,7 +3,7 @@ import "../../../styles/globals.scss";
 import { cleanup, render } from "@testing-library/react";
 import React from "react";
 import { afterEach, expect, it } from "vitest";
-import { commands, page } from "vitest/browser";
+import { commands, page, server } from "vitest/browser";
 
 import { Chart } from "../../../components/Chart/Chart";
 import {
@@ -20,11 +20,12 @@ it.each([
   ["border-box", 0.75],
   ["content-box", 0.75],
 ] as const)(
-  "keeps native pointer boundaries exact for fractional %s at scale %s",
+  "maps delivered native pointers across fractional %s boundaries at scale %s",
   async (boxSizing, scale) => {
     // Fit the runner window without its preview transform.
     await page.viewport(1200, 700);
     let latest: EngineEvent | undefined;
+    let native: { x: number; y: number } | undefined;
     const observe = (event: EngineEvent) => {
       if (event.signal.action === InputAction.MOVE) {
         latest = event;
@@ -52,6 +53,9 @@ it.each([
             type="line"
             x="x"
             y="y"
+            onPointerMove={(event) => {
+              native = { x: event.clientX, y: event.clientY };
+            }}
           >
             <Chart.Plot>
               <Chart.Series type="line" />
@@ -71,28 +75,79 @@ it.each([
     const width = Number(plot.getAttribute("width"));
     const height = Number(plot.getAttribute("height"));
     const rect = plot.getBoundingClientRect();
-    const hover = async (x: number, y: number) => {
+    const rootRect = container
+      .querySelector("[data-chart-container]")!
+      .getBoundingClientRect();
+    const svgRect = svg.getBoundingClientRect();
+    const borderWidth = boxSizing === "border-box" ? 600.25 : 631.75;
+    const borderHeight = boxSizing === "border-box" ? 300.25 : 323.75;
+    const hover = async (clientX: number, clientY: number) => {
       latest = undefined;
-      await commands.moveChartPointer(
-        rect.left + x * scale,
-        rect.top + y * scale,
-      );
+      native = undefined;
+      await commands.moveChartPointer(clientX, clientY);
       await expect.poll(() => latest).toBeDefined();
+      expect(native).toBeDefined();
+      // Firefox/WebKit deliver integer client coordinates; Firefox also
+      // quantizes transformed bounds. Assert the delivered event, not the request.
+      const expectedX =
+        ((native!.x - svgRect.left) * borderWidth) / rootRect.width - 40;
+      const expectedY =
+        ((native!.y - svgRect.top) * borderHeight) / rootRect.height - 20;
+      // Only allow floating-point operation-order noise, far below a layout pixel.
+      expect(latest!.chartX).toBeCloseTo(expectedX, 12);
+      expect(latest!.chartY).toBeCloseTo(expectedY, 12);
+      expect(latest!.isWithinPlot).toBe(
+        expectedX >= 0 &&
+          expectedX <= width &&
+          expectedY >= 0 &&
+          expectedY <= height,
+      );
+      if (server.browser === "chromium") {
+        expect(native).toEqual({ x: clientX, y: clientY });
+      }
     };
-    await hover(0, height / 2);
-    expect(latest?.chartX).toBe(0);
-    expect(latest?.isWithinPlot).toBe(true);
-    await hover(width / 2, 0);
-    expect(latest?.chartY).toBe(0);
-    expect(latest?.isWithinPlot).toBe(true);
-    await hover(width, height / 2);
-    expect(latest?.chartX).toBe(width);
-    expect(latest?.isWithinPlot).toBe(true);
-    await hover(width / 2, height);
-    expect(latest?.chartY).toBe(height);
-    expect(latest?.isWithinPlot).toBe(true);
-    await hover(-0.125, height / 2);
-    expect(latest?.chartX).toBe(-0.125);
-    expect(latest?.isWithinPlot).toBe(false);
+    const centerX = Math.floor(rect.left + rect.width / 2);
+    const centerY = Math.floor(rect.top + rect.height / 2);
+    await hover(rect.left, centerY);
+    if (server.browser === "chromium") {
+      expect(latest?.chartX).toBe(0);
+      expect(latest?.isWithinPlot).toBe(true);
+    }
+    await hover(centerX, rect.top);
+    if (server.browser === "chromium") {
+      expect(latest?.chartY).toBe(0);
+      expect(latest?.isWithinPlot).toBe(true);
+    }
+    await hover(rect.right, centerY);
+    if (server.browser === "chromium") {
+      expect(latest?.chartX).toBe(width);
+      expect(latest?.isWithinPlot).toBe(true);
+    }
+    await hover(centerX, rect.bottom);
+    if (server.browser === "chromium") {
+      expect(latest?.chartY).toBe(height);
+      expect(latest?.isWithinPlot).toBe(true);
+    }
+    if (server.browser === "chromium") {
+      await hover(rect.left - 0.125 * scale, centerY);
+      expect(latest?.chartX).toBe(-0.125);
+      expect(latest?.isWithinPlot).toBe(false);
+    }
+
+    // Integer requests immediately either side of every edge remain distinct
+    // even in engines whose native mouse events discard subpixels.
+    for (const [x, y, inside] of [
+      [Math.ceil(rect.left) + 1, centerY, true],
+      [Math.floor(rect.left) - 1, centerY, false],
+      [Math.floor(rect.right) - 1, centerY, true],
+      [Math.ceil(rect.right) + 1, centerY, false],
+      [centerX, Math.ceil(rect.top) + 1, true],
+      [centerX, Math.floor(rect.top) - 1, false],
+      [centerX, Math.floor(rect.bottom) - 1, true],
+      [centerX, Math.ceil(rect.bottom) + 1, false],
+    ] as const) {
+      await hover(x, y);
+      expect(latest?.isWithinPlot).toBe(inside);
+    }
   },
 );

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,6 +1,8 @@
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
+import { moveChartPointer } from "./tests/browser/Chart/coordinateCommands";
+
 /**
  * Real-browser lane.
  *
@@ -14,6 +16,7 @@ export default defineConfig({
     include: ["tests/browser/**/*.test.tsx"],
     browser: {
       enabled: true,
+      commands: { moveChartPointer },
       provider: playwright(),
       headless: true,
       screenshotFailures: false,


### PR DESCRIPTION
CSS-scaled charts used inconsistent viewport/local coordinates, selecting the wrong sample. Coordinate conversion now accounts for scaling and fractional border-box dimensions in both spatial and DOM hit testing.

Closes #90.

Validation: Red: unit and native-pointer regressions reproduced wrong scaled selection and false scaling from fractional widths. Green: 338 Chart unit tests, 103 Chromium browser tests, and 27 targeted checks across Chromium/Firefox/WebKit. Mutation verification rejected the original coordinate math in all 12 fractional browser cases.

Added source comments were reviewed for necessity. Combined verification with all nine fixes passed: 1,028 unit tests, 554 Chart checks across Chromium/Firefox/WebKit, 219 all-component Chromium checks, full typecheck, production build, four package tests, and 235 Storybook tests.
