### PR TITLE
Chart: support tap inspection and pointer cancellation

### DIFF
--- a/components/Chart/engine/Engine.ts
+++ b/components/Chart/engine/Engine.ts
@@ -144,6 +144,12 @@ export class Engine<T = unknown> {
       return;
     }
 
+    if (signal.action === InputAction.CANCEL) {
+      // Cancellation clears chart interactions, even when an outside touch has
+      // a different pointer ID from the work already queued for this chart.
+      this.scheduler.cancelPending();
+    }
+
     const plotOffset = this.coords.getPlotOffset();
     const searchX = signal.x - plotOffset.x;
     const searchY = signal.y - plotOffset.y;

--- a/components/Chart/engine/Scheduler.ts
+++ b/components/Chart/engine/Scheduler.ts
@@ -143,14 +143,18 @@ export class Scheduler<T = unknown> {
   }
 
   /**
-   * Cancel all pending tasks and clean up.
+   * Discard queued tasks while keeping the scheduler ready for new input.
    */
-  dispose(): void {
+  cancelPending(): void {
     if (this.rafId !== null) {
       cancelAnimationFrame(this.rafId);
       this.rafId = null;
     }
     this.visualQueue = [];
     this.idleQueue = [];
+  }
+
+  dispose(): void {
+    this.cancelPending();
   }
 }

--- a/components/Chart/sensors/DataHoverSensor/DataHoverSensor.test.ts
+++ b/components/Chart/sensors/DataHoverSensor/DataHoverSensor.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { EngineEvent, InputAction, InputSource } from "../../engine";
+import { Engine, EngineEvent, InputAction, InputSource } from "../../engine";
 import { SensorContext } from "../../types/events";
 import { InteractionChannel } from "../../types/interaction";
 import { DataHoverSensor } from "./DataHoverSensor";
@@ -254,4 +254,65 @@ describe("touch inspection", () => {
     );
     expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toBeNull();
   });
+});
+
+describe("engine-queued touch cancellation", () => {
+  it.each([1, 2])(
+    "does not restore a queued reading after cancellation by pointer %i",
+    (cancelId) => {
+      vi.useFakeTimers();
+      const ctx = createMockContext();
+      const sensor = DataHoverSensor();
+      const actions: InputAction[] = [];
+      const engine = new Engine({
+        onEvent: (event) => {
+          actions.push(event.signal.action);
+          sensor(event, ctx);
+        },
+      });
+      engine.updateBounds(new DOMRect(0, 0, 200, 200), {
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      });
+      engine.updateData([
+        { x: 50, y: 50, data: { value: 10 }, seriesId: "a", dataIndex: 0 },
+      ]);
+      const signal = {
+        id: 1,
+        source: InputSource.TOUCH,
+        action: InputAction.START,
+        x: 50,
+        y: 50,
+        timestamp: 0,
+        userId: "local",
+      };
+      try {
+        engine.input(signal);
+        expect(
+          ctx.getInteraction(InteractionChannel.PRIMARY_HOVER),
+        ).not.toBeNull();
+        engine.input({ ...signal, action: InputAction.MOVE });
+        engine.input({ ...signal, id: cancelId, action: InputAction.CANCEL });
+        vi.runAllTimers();
+        expect(actions).toEqual([InputAction.START, InputAction.CANCEL]);
+        expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toBeNull();
+
+        engine.input({ ...signal, action: InputAction.START });
+        engine.input({ ...signal, action: InputAction.MOVE });
+        vi.runAllTimers();
+        expect(
+          ctx.getInteraction(InteractionChannel.PRIMARY_HOVER),
+        ).not.toBeNull();
+        expect(actions.slice(-2)).toEqual([
+          InputAction.START,
+          InputAction.MOVE,
+        ]);
+      } finally {
+        engine.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/components/Chart/sensors/DataHoverSensor/DataHoverSensor.test.ts
+++ b/components/Chart/sensors/DataHoverSensor/DataHoverSensor.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { EngineEvent, InputAction } from "../../engine";
+import { EngineEvent, InputAction, InputSource } from "../../engine";
 import { SensorContext } from "../../types/events";
 import { InteractionChannel } from "../../types/interaction";
 import { DataHoverSensor } from "./DataHoverSensor";
@@ -193,5 +193,65 @@ describe("DataHoverSensor (Engine)", () => {
       InteractionChannel.PRIMARY_HOVER,
     );
     expect(ctx.upsertInteraction).not.toHaveBeenCalled();
+  });
+});
+
+describe("touch inspection", () => {
+  it("inspects a vertical slice on touch start and retains it on release", () => {
+    const ctx = createMockContext();
+    const sensor = DataHoverSensor({ verticalSlice: true });
+    const candidates = [
+      {
+        type: "data-point" as const,
+        data: { value: 10 },
+        seriesId: "a",
+        coordinate: { x: 10, y: 10 },
+        distance: 0,
+      },
+      {
+        type: "data-point" as const,
+        data: { value: 20 },
+        seriesId: "b",
+        coordinate: { x: 10, y: 20 },
+        distance: 10,
+      },
+    ];
+    const event = createMockEvent(InputAction.START, candidates[0]);
+    event.signal.source = InputSource.TOUCH;
+    event.sliceCandidates = candidates;
+    sensor(event, ctx);
+    sensor(
+      { ...event, signal: { ...event.signal, action: InputAction.END } },
+      ctx,
+    );
+    expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toMatchObject({
+      pointer: { isTouch: true },
+      targets: candidates,
+    });
+    sensor(
+      { ...event, signal: { ...event.signal, action: InputAction.CANCEL } },
+      ctx,
+    );
+    expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toBeNull();
+  });
+
+  it("dismisses a reading when touching outside the plot", () => {
+    const ctx = createMockContext();
+    const sensor = DataHoverSensor();
+    const event = createMockEvent(InputAction.MOVE, { data: { value: 10 } });
+    sensor(event, ctx);
+    sensor(
+      {
+        ...event,
+        isWithinPlot: false,
+        signal: {
+          ...event.signal,
+          source: InputSource.TOUCH,
+          action: InputAction.START,
+        },
+      },
+      ctx,
+    );
+    expect(ctx.getInteraction(InteractionChannel.PRIMARY_HOVER)).toBeNull();
   });
 });

--- a/components/Chart/sensors/DataHoverSensor/DataHoverSensor.ts
+++ b/components/Chart/sensors/DataHoverSensor/DataHoverSensor.ts
@@ -50,14 +50,16 @@ export const DataHoverSensor = (options: HoverSensorOptions = {}): Sensor => {
 
     if (
       signal.action !== InputAction.MOVE &&
-      signal.action !== InputAction.CANCEL
+      signal.action !== InputAction.CANCEL &&
+      !(signal.source === "touch" && signal.action === InputAction.START)
     ) {
       return;
     }
 
     if (
       signal.action === InputAction.CANCEL ||
-      (!isWithinPlot && signal.source !== "touch")
+      (!isWithinPlot &&
+        (signal.source !== "touch" || signal.action === InputAction.START))
     ) {
       removeInteraction(name);
       return;

--- a/components/Chart/subcomponents/InteractionLayer/InteractionLayer.test.tsx
+++ b/components/Chart/subcomponents/InteractionLayer/InteractionLayer.test.tsx
@@ -250,6 +250,60 @@ describe("InteractionLayer", () => {
   // ===========================================================================
 
   describe("Throttling", () => {
+    it("forwards pointercancel immediately and discards a queued move", () => {
+      let queued: FrameRequestCallback = () => {};
+      vi.mocked(window.requestAnimationFrame).mockImplementation((callback) => {
+        queued = callback;
+        return 7;
+      });
+      render(
+        <ContainerWrapper>
+          <InteractionLayer />
+        </ContainerWrapper>,
+      );
+      const container = document.querySelector("[data-chart-container]")!;
+      fireEvent.pointerMove(container, { pointerType: "touch" });
+      fireEvent.pointerCancel(container, { pointerType: "touch" });
+      expect(mockCreateSignal).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "pointercancel" }),
+        "CANCEL",
+      );
+      expect(window.cancelAnimationFrame).toHaveBeenCalledWith(7);
+      queued(0);
+      expect(mockEngineInput).toHaveBeenCalledTimes(1);
+    });
+
+    it("dismisses on an outside touch without cancelling an inside touch", () => {
+      render(
+        <ContainerWrapper>
+          <InteractionLayer />
+        </ContainerWrapper>,
+      );
+      const container = document.querySelector("[data-chart-container]")!;
+      fireEvent.pointerDown(container, { pointerType: "touch" });
+      fireEvent.pointerDown(document.body, { pointerType: "touch" });
+      expect(mockCreateSignal.mock.calls.map((call) => call[1])).toEqual([
+        "START",
+        "CANCEL",
+      ]);
+    });
+
+    it("retains touch inspection across the automatic leave after release", () => {
+      render(
+        <ContainerWrapper>
+          <InteractionLayer />
+        </ContainerWrapper>,
+      );
+      const container = document.querySelector("[data-chart-container]")!;
+      fireEvent.pointerDown(container, { pointerType: "touch" });
+      fireEvent.pointerUp(container, { pointerType: "touch" });
+      fireEvent.pointerLeave(container, { pointerType: "touch" });
+      expect(mockCreateSignal.mock.calls.map((call) => call[1])).toEqual([
+        "START",
+        "END",
+      ]);
+    });
+
     it("coalesces pointermove events into one engine input per frame", () => {
       // Hold the frame instead of running it, so we can observe what is queued.
       let frameCallback: FrameRequestCallback | null = null;
@@ -362,6 +416,7 @@ describe("InteractionLayer", () => {
       // cleanup returns early, and says nothing about which element it ran on.
       expect(removed.sort()).toEqual([
         "keydown",
+        "pointercancel",
         "pointerdown",
         "pointerleave",
         "pointermove",

--- a/components/Chart/subcomponents/InteractionLayer/InteractionLayer.tsx
+++ b/components/Chart/subcomponents/InteractionLayer/InteractionLayer.tsx
@@ -32,6 +32,14 @@ export const InteractionLayer: React.FC = () => {
       return;
     }
 
+    const clearPendingMove = () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+      }
+      frameRef.current = null;
+      lastEventRef.current = null;
+    };
+
     // 2. Define the throttled processor
     const processEvent = () => {
       const event = lastEventRef.current;
@@ -55,18 +63,21 @@ export const InteractionLayer: React.FC = () => {
 
     // 3. Define the listener (Throttler)
     const onPointerEvent = (e: PointerEvent) => {
+      // Touch emits pointerleave on release even though its reading should remain.
+      if (e.type === "pointerleave" && e.pointerType === "touch") {
+        return;
+      }
+
       // CRITICAL: Do NOT throttle state-change events (down, up, leave).
       // These need immediate processing for proper drag/click handling.
       if (
         e.type === "pointerdown" ||
         e.type === "pointerup" ||
-        e.type === "pointerleave"
+        e.type === "pointerleave" ||
+        e.type === "pointercancel"
       ) {
         // Cancel any pending frame to avoid processing stale events
-        if (frameRef.current) {
-          cancelAnimationFrame(frameRef.current);
-          frameRef.current = null;
-        }
+        clearPendingMove();
 
         // Force synchronous processing
         lastEventRef.current = e;
@@ -78,6 +89,20 @@ export const InteractionLayer: React.FC = () => {
       lastEventRef.current = e;
       if (!frameRef.current) {
         frameRef.current = requestAnimationFrame(processEvent);
+      }
+    };
+
+    const onOutsidePointerDown = (event: PointerEvent) => {
+      if (
+        event.pointerType !== "touch" ||
+        event.composedPath().includes(container)
+      ) {
+        return;
+      }
+      clearPendingMove();
+      const signal = engine.createSignal(event, InputAction.CANCEL);
+      if (signal) {
+        engine.input(signal);
       }
     };
 
@@ -101,10 +126,20 @@ export const InteractionLayer: React.FC = () => {
     };
 
     // 4. Attach Listeners
-    container.addEventListener("pointermove", onPointerEvent);
-    container.addEventListener("pointerdown", onPointerEvent);
+    container.addEventListener("pointermove", onPointerEvent, {
+      passive: true,
+    });
+    container.addEventListener("pointerdown", onPointerEvent, {
+      passive: true,
+    });
     container.addEventListener("pointerup", onPointerEvent);
     container.addEventListener("pointerleave", onPointerEvent);
+    container.addEventListener("pointercancel", onPointerEvent);
+    container.ownerDocument.addEventListener(
+      "pointerdown",
+      onOutsidePointerDown,
+      { capture: true, passive: true },
+    );
     container.addEventListener("keydown", onKeyDown);
 
     return () => {
@@ -112,10 +147,14 @@ export const InteractionLayer: React.FC = () => {
       container.removeEventListener("pointerdown", onPointerEvent);
       container.removeEventListener("pointerup", onPointerEvent);
       container.removeEventListener("pointerleave", onPointerEvent);
+      container.removeEventListener("pointercancel", onPointerEvent);
+      container.ownerDocument.removeEventListener(
+        "pointerdown",
+        onOutsidePointerDown,
+        true,
+      );
       container.removeEventListener("keydown", onKeyDown);
-      if (frameRef.current) {
-        cancelAnimationFrame(frameRef.current);
-      }
+      clearPendingMove();
     };
   }, [engine, chartStore]);
 
@@ -141,6 +180,7 @@ function getInputAction(nativeType: string): InputAction {
       return InputAction.START;
     case "pointerup":
       return InputAction.END;
+    case "pointercancel":
     case "pointerleave":
       return InputAction.CANCEL;
     default:

--- a/tests/browser/Chart/touch.test.tsx
+++ b/tests/browser/Chart/touch.test.tsx
@@ -1,0 +1,124 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, expect, it } from "vitest";
+import { cdp } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+const rows = [
+  { month: "Jan", actual: 10, forecast: 20 },
+  { month: "Feb", actual: 30, forecast: 40 },
+  { month: "Mar", actual: 20, forecast: 30 },
+];
+const frame = () =>
+  new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+let touching = false;
+const touch = async (
+  type: "touchStart" | "touchMove" | "touchEnd" | "touchCancel",
+  point?: { x: number; y: number },
+) => {
+  if (type === "touchStart") touching = true;
+  await cdp().send("Input.dispatchTouchEvent", {
+    type,
+    touchPoints: point ? [{ ...point, id: 1 }] : [],
+  });
+  if (type === "touchEnd" || type === "touchCancel") touching = false;
+  await frame();
+};
+const tap = async (point: { x: number; y: number }) => {
+  await touch("touchStart", point);
+  await touch("touchEnd");
+};
+const centre = (element: Element) => {
+  const box = element.getBoundingClientRect();
+  return { x: box.left + box.width / 2, y: box.top + box.height / 2 };
+};
+const mount = async () => {
+  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: true });
+  const result = render(
+    <DesignSystemProvider>
+      <div style={{ minHeight: 1800 }}>
+        <Chart.Root
+          data={rows}
+          type="line"
+          x="month"
+          y="actual"
+          style={{ width: 600, height: 360 }}
+        >
+          <Chart.Plot>
+            <Chart.Series type="line" y="actual" label="Actual" showDots />
+            <Chart.Series type="line" y="forecast" label="Forecast" showDots />
+          </Chart.Plot>
+        </Chart.Root>
+        <button>Outside chart</button>
+      </div>
+    </DesignSystemProvider>,
+  );
+  await expect
+    .poll(() => result.container.querySelectorAll("circle").length)
+    .toBeGreaterThanOrEqual(6);
+  await frame();
+  const root = result.container.querySelector("[data-chart-container]")!;
+  const live = root.querySelector('[aria-live="polite"]')!;
+  const point = centre(root.querySelectorAll("circle")[1]);
+  return { ...result, root, live, point };
+};
+afterEach(async () => {
+  if (touching) await touch("touchCancel");
+  await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: false });
+  cleanup();
+  window.scrollTo(0, 0);
+});
+
+it("native tap retains the multi-series tooltip and live reading until an outside tap", async () => {
+  const { container, root, live, point } = await mount();
+  const events: PointerEvent[] = [];
+  root.addEventListener("pointerdown", (event) =>
+    events.push(event as PointerEvent),
+  );
+  await tap(point);
+  expect(events[0].isTrusted).toBe(true);
+  expect(events[0].pointerType).toBe("touch");
+  await expect.poll(() => live.textContent).toContain("Feb");
+  const tooltip = root.querySelector("[data-chart-tooltip]")!;
+  expect(tooltip.textContent).toContain("30");
+  expect(tooltip.textContent).toContain("40");
+  await expect.poll(() => getComputedStyle(tooltip).opacity).toBe("1");
+  await tap(centre(container.querySelector("button")!));
+  await expect.poll(() => live.textContent).toBe("");
+  await expect
+    .poll(() => root.querySelector("[data-chart-tooltip]"))
+    .toBeNull();
+});
+
+it("native cancellation clears the transient touch reading", async () => {
+  const { root, live, point } = await mount();
+  await touch("touchStart", point);
+  await expect.poll(() => live.textContent).toContain("Feb");
+  await touch("touchCancel");
+  await expect.poll(() => live.textContent).toBe("");
+  await expect
+    .poll(() => root.querySelector("[data-chart-tooltip]"))
+    .toBeNull();
+});
+
+it("native vertical swiping scrolls the page and clears inspection", async () => {
+  const { root, live, point } = await mount();
+  let cancelled = false;
+  root.addEventListener("pointercancel", () => {
+    cancelled = true;
+  });
+  await touch("touchStart", point);
+  for (const distance of [5, 30, 70, 110]) {
+    await touch("touchMove", { x: point.x, y: point.y - distance });
+  }
+  await touch("touchEnd");
+  await expect.poll(() => window.scrollY).toBeGreaterThan(0);
+  expect(cancelled).toBe(true);
+  await expect.poll(() => live.textContent).toBe("");
+});

--- a/tests/browser/Chart/touch.test.tsx
+++ b/tests/browser/Chart/touch.test.tsx
@@ -6,6 +6,12 @@ import { afterEach, expect, it } from "vitest";
 import { cdp } from "vitest/browser";
 
 import { Chart } from "../../../components/Chart/Chart";
+import { useChartContext } from "../../../components/Chart/context";
+import {
+  Engine,
+  InputAction,
+  type InputSignal,
+} from "../../../components/Chart/engine";
 import { DesignSystemProvider } from "../../../DesignSystemProvider";
 
 const rows = [
@@ -43,6 +49,11 @@ const centre = (element: Element) => {
   return { x: box.left + box.width / 2, y: box.top + box.height / 2 };
 };
 const mount = async () => {
+  let engine: Engine | null = null;
+  const CaptureEngine = () => {
+    engine = useChartContext().engine;
+    return null;
+  };
   await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: true });
   const result = render(
     <DesignSystemProvider>
@@ -54,6 +65,7 @@ const mount = async () => {
           x="month"
           y="actual"
         >
+          <CaptureEngine />
           <Chart.Plot>
             <Chart.Series showDots label="Actual" type="line" y="actual" />
             <Chart.Series showDots label="Forecast" type="line" y="forecast" />
@@ -70,7 +82,7 @@ const mount = async () => {
   const root = result.container.querySelector("[data-chart-container]")!;
   const live = root.querySelector('[aria-live="polite"]')!;
   const point = centre(root.querySelectorAll("circle")[1]);
-  return { ...result, root, live, point };
+  return { ...result, root, live, point, engine: engine! };
 };
 afterEach(async () => {
   if (touching) {
@@ -128,3 +140,58 @@ it("native vertical swiping scrolls the page and clears inspection", async () =>
   expect(cancelled).toBe(true);
   await expect.poll(() => live.textContent).toBe("");
 });
+
+it.each(["pointercancel", "outside touch"] as const)(
+  "does not revive an engine-queued reading after native %s",
+  async (dismissal) => {
+    const { container, root, live, point, engine } = await mount();
+    let start: InputSignal | null = null;
+    root.addEventListener(
+      "pointerdown",
+      (event) => {
+        start = engine.createSignal(event as PointerEvent, InputAction.START);
+      },
+      { once: true },
+    );
+    await touch("touchStart", point);
+    if (dismissal === "outside touch") {
+      await touch("touchEnd");
+    }
+    await expect.poll(() => live.textContent).toContain("Feb");
+    expect(start).not.toBeNull();
+    let queued = false;
+    const eventType =
+      dismissal === "pointercancel" ? "pointercancel" : "pointerdown";
+    // Queue a real engine MOVE immediately before native dismissal reaches the
+    // layer, deterministically reproducing work that passed its first RAF.
+    const queueMove = (event: PointerEvent) => {
+      expect(event.isTrusted).toBe(true);
+      expect(event.pointerType).toBe("touch");
+      if (dismissal === "outside touch") {
+        expect(event.pointerId).not.toBe(start!.id);
+      } else {
+        expect(event.pointerId).toBe(start!.id);
+      }
+      engine.input({ ...start!, action: InputAction.MOVE });
+      queued = true;
+    };
+    window.addEventListener(eventType, queueMove, {
+      capture: true,
+      once: true,
+    });
+    try {
+      if (dismissal === "pointercancel") {
+        await touch("touchCancel");
+      } else {
+        await tap(centre(container.querySelector("button")!));
+      }
+      expect(queued).toBe(true);
+      await expect.poll(() => live.textContent).toBe("");
+      await expect
+        .poll(() => root.querySelector("[data-chart-tooltip]"))
+        .toBeNull();
+    } finally {
+      window.removeEventListener(eventType, queueMove, true);
+    }
+  },
+);

--- a/tests/browser/Chart/touch.test.tsx
+++ b/tests/browser/Chart/touch.test.tsx
@@ -22,12 +22,16 @@ const touch = async (
   type: "touchStart" | "touchMove" | "touchEnd" | "touchCancel",
   point?: { x: number; y: number },
 ) => {
-  if (type === "touchStart") touching = true;
+  if (type === "touchStart") {
+    touching = true;
+  }
   await cdp().send("Input.dispatchTouchEvent", {
     type,
     touchPoints: point ? [{ ...point, id: 1 }] : [],
   });
-  if (type === "touchEnd" || type === "touchCancel") touching = false;
+  if (type === "touchEnd" || type === "touchCancel") {
+    touching = false;
+  }
   await frame();
 };
 const tap = async (point: { x: number; y: number }) => {
@@ -45,14 +49,14 @@ const mount = async () => {
       <div style={{ minHeight: 1800 }}>
         <Chart.Root
           data={rows}
+          style={{ width: 600, height: 360 }}
           type="line"
           x="month"
           y="actual"
-          style={{ width: 600, height: 360 }}
         >
           <Chart.Plot>
-            <Chart.Series type="line" y="actual" label="Actual" showDots />
-            <Chart.Series type="line" y="forecast" label="Forecast" showDots />
+            <Chart.Series showDots label="Actual" type="line" y="actual" />
+            <Chart.Series showDots label="Forecast" type="line" y="forecast" />
           </Chart.Plot>
         </Chart.Root>
         <button>Outside chart</button>
@@ -69,7 +73,9 @@ const mount = async () => {
   return { ...result, root, live, point };
 };
 afterEach(async () => {
-  if (touching) await touch("touchCancel");
+  if (touching) {
+    await touch("touchCancel");
+  }
   await cdp().send("Emulation.setTouchEmulationEnabled", { enabled: false });
   cleanup();
   window.scrollTo(0, 0);

--- a/tests/browser/Chart/touch.test.tsx
+++ b/tests/browser/Chart/touch.test.tsx
@@ -59,6 +59,7 @@ const mount = async () => {
     <DesignSystemProvider>
       <div style={{ minHeight: 1800 }}>
         <Chart.Root
+          d3Config={{ showDots: true }}
           data={rows}
           style={{ width: 600, height: 360 }}
           type="line"
@@ -67,8 +68,8 @@ const mount = async () => {
         >
           <CaptureEngine />
           <Chart.Plot>
-            <Chart.Series showDots label="Actual" type="line" y="actual" />
-            <Chart.Series showDots label="Forecast" type="line" y="forecast" />
+            <Chart.Series label="Actual" type="line" y="actual" />
+            <Chart.Series label="Forecast" type="line" y="forecast" />
           </Chart.Plot>
         </Chart.Root>
         <button>Outside chart</button>


### PR DESCRIPTION
Touch taps did not inspect values and cancelled input could leave or restore stale tooltips. Native touch inspection now persists until dismissal; cancellation also invalidates queued engine work.

Closes #91.

Validation: Red: six touch unit regressions plus native tap/cancel tests; additional real-engine and native-browser races reproduced queued hover resurrection. Green: 335 Chart unit tests, 99 Chromium browser tests, production compilation, and integration typechecking. Native touch coverage uses trusted Chromium CDP input; physical devices and Safari touch are not claimed.

Added source comments were reviewed for necessity. Combined verification with all nine fixes passed: 1,028 unit tests, 554 Chart checks across Chromium/Firefox/WebKit, 219 all-component Chromium checks, full typecheck, production build, four package tests, and 235 Storybook tests.
