### PR TITLE
Chart: handle missing and invalid samples consistently

### DIFF
--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -4,12 +4,13 @@ import * as d3Scale from "d3-scale";
 import * as d3Shape from "d3-shape";
 import { Info } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
-import { expect, userEvent, waitFor } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { palette } from "../../styles/palettes";
 import { Badge } from "../Badge/Badge";
 import { Button } from "../Button/Button";
 import { Card } from "../Card/Card";
+import { Checkbox } from "../Checkbox/Checkbox";
 import { Chip } from "../Chip/Chip";
 import { Flex, Stack } from "../Layout/Layout";
 import { Select } from "../Select/Select";
@@ -101,7 +102,79 @@ const data = [
   { label: "Jun", value: 45 },
 ];
 
+function LineChartExample(args: React.ComponentProps<typeof Chart>) {
+  const [showMissing, setShowMissing] = useState(false);
+  const missingData = data.map((datum, index) => ({
+    ...datum,
+    value: index === 2 ? null : index === 3 ? 0 : datum.value,
+  }));
+  return (
+    <Stack gap={3} style={{ width: "100%" }}>
+      <Checkbox
+        checked={showMissing}
+        label="Show missing data"
+        onChange={(event) => setShowMissing(event.target.checked)}
+      />
+      {showMissing && (
+        <Text variant="body">
+          March has no reading, so the line has a gap. April is a measured zero
+          and remains available to inspect.
+        </Text>
+      )}
+      <Chart {...args} data={showMissing ? missingData : args.data} />
+    </Stack>
+  );
+}
+
 export const LineChart: Story = {
+  render: (args) => <LineChartExample {...args} />,
+  tags: ["interaction"],
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step(
+      "Missing March forms a gap while April remains a valid zero",
+      async () => {
+        const toggle = canvas.getByRole("checkbox", {
+          name: "Show missing data",
+        });
+        await userEvent.click(toggle);
+        await waitFor(() => {
+          expect(
+            canvasElement.querySelectorAll(".chart-line-series circle"),
+          ).toHaveLength(5);
+          const path = canvasElement.querySelector(".chart-line-series path")!;
+          expect(path.getAttribute("d")?.match(/M/g)).toHaveLength(2);
+          expect(
+            canvas.queryByRole("graphics-symbol", { name: /^Mar:/ }),
+          ).toBeNull();
+          expect(
+            canvas.queryByRole("graphics-symbol", { name: "Apr: 0" }),
+          ).not.toBeNull();
+        });
+        const chart = canvasElement.querySelector<HTMLElement>(
+          "[data-chart-container]",
+        )!;
+        chart.focus();
+        await userEvent.keyboard(
+          "{Escape}{ArrowRight}{ArrowRight}{ArrowRight}",
+        );
+        await waitFor(() => {
+          const tooltip = canvasElement.querySelector("[data-chart-tooltip]")!;
+          expect(tooltip).toHaveTextContent("Apr");
+          expect(
+            within(tooltip as HTMLElement).getByText("0", { exact: true }),
+          ).toBeInTheDocument();
+        });
+        await userEvent.keyboard("{Escape}");
+        await userEvent.click(toggle);
+        await waitFor(() =>
+          expect(
+            canvasElement.querySelectorAll(".chart-line-series circle"),
+          ).toHaveLength(6),
+        );
+      },
+    );
+  },
   args: {
     data,
     x: (d: any) => d.label,

--- a/components/Chart/Chart.stories.tsx
+++ b/components/Chart/Chart.stories.tsx
@@ -4,13 +4,12 @@ import * as d3Scale from "d3-scale";
 import * as d3Shape from "d3-shape";
 import { Info } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
-import { expect, userEvent, waitFor, within } from "storybook/test";
+import { expect, userEvent, waitFor } from "storybook/test";
 
 import { palette } from "../../styles/palettes";
 import { Badge } from "../Badge/Badge";
 import { Button } from "../Button/Button";
 import { Card } from "../Card/Card";
-import { Checkbox } from "../Checkbox/Checkbox";
 import { Chip } from "../Chip/Chip";
 import { Flex, Stack } from "../Layout/Layout";
 import { Select } from "../Select/Select";
@@ -102,79 +101,7 @@ const data = [
   { label: "Jun", value: 45 },
 ];
 
-function LineChartExample(args: React.ComponentProps<typeof Chart>) {
-  const [showMissing, setShowMissing] = useState(false);
-  const missingData = data.map((datum, index) => ({
-    ...datum,
-    value: index === 2 ? null : index === 3 ? 0 : datum.value,
-  }));
-  return (
-    <Stack gap={3} style={{ width: "100%" }}>
-      <Checkbox
-        checked={showMissing}
-        label="Show missing data"
-        onChange={(event) => setShowMissing(event.target.checked)}
-      />
-      {showMissing && (
-        <Text variant="body">
-          March has no reading, so the line has a gap. April is a measured zero
-          and remains available to inspect.
-        </Text>
-      )}
-      <Chart {...args} data={showMissing ? missingData : args.data} />
-    </Stack>
-  );
-}
-
 export const LineChart: Story = {
-  render: (args) => <LineChartExample {...args} />,
-  tags: ["interaction"],
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-    await step(
-      "Missing March forms a gap while April remains a valid zero",
-      async () => {
-        const toggle = canvas.getByRole("checkbox", {
-          name: "Show missing data",
-        });
-        await userEvent.click(toggle);
-        await waitFor(() => {
-          expect(
-            canvasElement.querySelectorAll(".chart-line-series circle"),
-          ).toHaveLength(5);
-          const path = canvasElement.querySelector(".chart-line-series path")!;
-          expect(path.getAttribute("d")?.match(/M/g)).toHaveLength(2);
-          expect(
-            canvas.queryByRole("graphics-symbol", { name: /^Mar:/ }),
-          ).toBeNull();
-          expect(
-            canvas.queryByRole("graphics-symbol", { name: "Apr: 0" }),
-          ).not.toBeNull();
-        });
-        const chart = canvasElement.querySelector<HTMLElement>(
-          "[data-chart-container]",
-        )!;
-        chart.focus();
-        await userEvent.keyboard(
-          "{Escape}{ArrowRight}{ArrowRight}{ArrowRight}",
-        );
-        await waitFor(() => {
-          const tooltip = canvasElement.querySelector("[data-chart-tooltip]")!;
-          expect(tooltip).toHaveTextContent("Apr");
-          expect(
-            within(tooltip as HTMLElement).getByText("0", { exact: true }),
-          ).toBeInTheDocument();
-        });
-        await userEvent.keyboard("{Escape}");
-        await userEvent.click(toggle);
-        await waitFor(() =>
-          expect(
-            canvasElement.querySelectorAll(".chart-line-series circle"),
-          ).toHaveLength(6),
-        );
-      },
-    );
-  },
   args: {
     data,
     x: (d: any) => d.label,

--- a/components/Chart/sensors/KeyboardSensor/KeyboardSensor.ts
+++ b/components/Chart/sensors/KeyboardSensor/KeyboardSensor.ts
@@ -4,6 +4,7 @@ import { Sensor } from "../../types/events";
 import { InteractionChannel } from "../../types/interaction";
 import { barGeometry, categoryAccessor } from "../../utils/bars";
 import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import { samplePosition } from "../../utils/sampleValidity";
 import { hasDomainOverride } from "../../utils/scales";
 
 /**
@@ -27,11 +28,17 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
     const state = chartStore.getState();
     const { scales, x: xAccessor, y: yAccessor } = state;
     const firstSeries = state.processedSeries?.[0];
-    const entries = (firstSeries?.data ?? state.data).map((datum, index) => ({
-      datum,
-      index,
-      series: firstSeries,
-    }));
+    const entries = (firstSeries?.data ?? state.data).flatMap((datum, index) =>
+      datum == null
+        ? []
+        : [
+            {
+              datum,
+              index,
+              series: firstSeries,
+            },
+          ],
+    );
     const firstCategory = firstSeries && categoryAccessor(firstSeries);
     const seen = new Set(
       entries.map((entry) =>
@@ -46,6 +53,9 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
         continue;
       }
       (series.data ?? []).forEach((datum, index) => {
+        if (datum == null) {
+          return;
+        }
         const category = resolveAccessor(accessor)(datum);
         if (!seen.has(category)) {
           entries.push({ datum, index, series });
@@ -79,6 +89,9 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
         if (accessor) {
           const getCategory = resolveAccessor(accessor);
           (series.data ?? []).forEach((datum, index) => {
+            if (datum == null) {
+              return;
+            }
             const value = getCategory(datum);
             // Match findIndex's first occurrence and strict equality for NaN.
             if (!Number.isNaN(value) && !indices.has(value)) {
@@ -94,19 +107,19 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
     const slices = entries
       .map((entry) => {
         const d = entry.datum;
+        const primaryPosition = samplePosition(
+          d,
+          xAccessor ? resolveAccessor(xAccessor) : (datum) => datum[0],
+          yAccessor ? resolveAccessor(yAccessor) : (datum) => datum[1],
+          xScale,
+          yScale,
+        );
         const primaryTarget = {
           type: "data-point",
           data: d,
           seriesId: "default",
           dataIndex: entry.index,
-          coordinate: {
-            x: (xScale as (v: unknown) => number)(
-              xAccessor ? resolveAccessor(xAccessor)(d) : d[0],
-            ),
-            y: (yScale as (v: unknown) => number)(
-              yAccessor ? resolveAccessor(yAccessor)(d) : d[1],
-            ),
-          },
+          coordinate: primaryPosition ?? { x: NaN, y: NaN },
           distance: 0,
         };
         const category = entry.series && categoryAccessor(entry.series);
@@ -122,6 +135,18 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
             return [];
           }
           const datum = series.data![index];
+          const sample = samplePosition(
+            datum,
+            series.xAccessor ? resolveAccessor(series.xAccessor) : () => index,
+            series.yAccessor
+              ? resolveAccessor(series.yAccessor)
+              : (value) => value,
+            xScale,
+            yScale,
+          );
+          if (!sample) {
+            return [];
+          }
           const geometry =
             series.type === "bar"
               ? barGeometry(series, datum, index, xScale, yScale)
@@ -133,20 +158,8 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
           if (series.type === "bar" && !bar) {
             return [];
           }
-          const x = bar
-            ? bar.x + bar.width / 2
-            : (xScale as (v: unknown) => number)(
-                series.xAccessor
-                  ? resolveAccessor(series.xAccessor)(datum)
-                  : index,
-              );
-          const y = bar
-            ? bar.y + bar.height / 2
-            : (yScale as (v: unknown) => number)(
-                series.yAccessor
-                  ? resolveAccessor(series.yAccessor)(datum)
-                  : datum,
-              );
+          const x = bar ? bar.x + bar.width / 2 : sample.x;
+          const y = bar ? bar.y + bar.height / 2 : sample.y;
           if (bounded && !isPointInPlot({ x, y }, state.dimensions)) {
             return [];
           }
@@ -164,8 +177,8 @@ export const KeyboardSensor = (options: { name?: string } = {}): Sensor => {
         });
         return targets.length || entry.series
           ? targets
-          : !bounded ||
-              isPointInPlot(primaryTarget.coordinate, state.dimensions)
+          : primaryPosition &&
+              (!bounded || isPointInPlot(primaryPosition, state.dimensions))
             ? [primaryTarget]
             : [];
       })

--- a/components/Chart/sensors/KeyboardSensor/sampleValidity.test.ts
+++ b/components/Chart/sensors/KeyboardSensor/sampleValidity.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "vitest";
+
+import { type EngineEvent, InputAction, InputSource } from "../../engine";
+import {
+  createChartStore,
+  registerSeries,
+  removeInteraction,
+  updateChartState,
+  upsertInteraction,
+} from "../../state/store/chart.store";
+import type { SensorContext } from "../../types/events";
+import {
+  type HoverInteraction,
+  InteractionChannel,
+} from "../../types/interaction";
+import { KeyboardSensor } from "./KeyboardSensor";
+
+it.each([false, true])(
+  "skips missing and nonfinite keyboard targets with original indices (registered=%s)",
+  (registered) => {
+    const data = new Array<{ x: number; y: number | null }>(6);
+    data[1] = { x: 1, y: null };
+    data[2] = { x: 2, y: 0 };
+    data[3] = { x: 3, y: Infinity };
+    data[4] = { x: 4, y: 20 };
+    const store = createChartStore({ width: 400, height: 300 }, "x", "y");
+    updateChartState(store, { data, dimensions: store.getState().dimensions });
+    if (registered) {
+      registerSeries(store, "s", [{ id: "s", x: "x", y: "y" }]);
+    }
+    const context = {
+      getChartContext: () => ({ chartStore: store }),
+      upsertInteraction: (name: string, payload: unknown) =>
+        upsertInteraction(store, name, payload),
+      removeInteraction: (name: string) => removeInteraction(store, name),
+    } as SensorContext;
+    const event: EngineEvent = {
+      signal: {
+        action: InputAction.KEY,
+        key: "ArrowRight",
+        source: InputSource.KEYBOARD,
+        id: 0,
+        x: 0,
+        y: 0,
+        timestamp: 0,
+        userId: "local",
+      },
+      candidates: [],
+      sliceCandidates: [],
+      chartX: 0,
+      chartY: 0,
+      isWithinPlot: true,
+    };
+    const sensor = KeyboardSensor();
+    for (const index of [2, 4, 4]) {
+      sensor(event, context);
+      const hover = store
+        .getState()
+        .interactions.get(InteractionChannel.PRIMARY_HOVER) as HoverInteraction;
+      expect(hover.targets.map((target) => target.dataIndex)).toEqual([index]);
+      expect(hover.targets[0].data).toBe(data[index]);
+    }
+  },
+);

--- a/components/Chart/sensors/KeyboardSensor/sampleValidity.test.ts
+++ b/components/Chart/sensors/KeyboardSensor/sampleValidity.test.ts
@@ -53,7 +53,7 @@ it.each([false, true])(
     };
     const sensor = KeyboardSensor();
     for (const index of [2, 4, 4]) {
-      sensor(event, context);
+      sensor({ ...event, signal: { ...event.signal } }, context);
       const hover = store
         .getState()
         .interactions.get(InteractionChannel.PRIMARY_HOVER) as HoverInteraction;

--- a/components/Chart/state/store/chart.store.ts
+++ b/components/Chart/state/store/chart.store.ts
@@ -4,7 +4,11 @@ import { resolveAccessor } from "../../utils/accessors";
 import { barGeometry, categoryAccessor, stackSeries } from "../../utils/bars";
 import { d3 } from "../../utils/d3";
 import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
-import { samplePosition } from "../../utils/sampleValidity";
+import {
+  isSampleValue,
+  numericSample,
+  samplePosition,
+} from "../../utils/sampleValidity";
 import {
   createScales,
   hasDomainOverride,
@@ -509,7 +513,13 @@ const deriveScales = (data: State["data"], dims: Dimensions, state: State) => {
     );
     const categories = compatible.flatMap((series) => {
       const accessor = categoryAccessor(series);
-      return accessor ? (series.data ?? []).map(resolveAccessor(accessor)) : [];
+      return accessor
+        ? (series.data ?? [])
+            .flatMap((datum) =>
+              datum == null ? [] : [resolveAccessor(accessor)(datum)],
+            )
+            .filter(isSampleValue)
+        : [];
     });
     const totals = compatible.flatMap(
       (series) => series.stackRanges?.flat() ?? [],
@@ -544,12 +554,14 @@ const deriveScales = (data: State["data"], dims: Dimensions, state: State) => {
       const extraValues = otherSeries
         .flatMap((series) =>
           series.yAccessor
-            ? (series.data ?? []).map((datum) =>
-                Number(resolveAccessor(series.yAccessor!)(datum)),
+            ? (series.data ?? []).flatMap((datum) =>
+                datum == null
+                  ? []
+                  : [numericSample(resolveAccessor(series.yAccessor!)(datum))],
               )
             : [],
         )
-        .filter(Number.isFinite);
+        .filter((value): value is number => value !== undefined);
       const bounds = base.yScale.domain();
       base.yScale
         .domain([
@@ -559,7 +571,13 @@ const deriveScales = (data: State["data"], dims: Dimensions, state: State) => {
         .nice();
       const extras = otherSeries.flatMap((series) =>
         series.xAccessor
-          ? (series.data ?? []).map(resolveAccessor(series.xAccessor))
+          ? (series.data ?? [])
+              .flatMap((datum) =>
+                datum == null
+                  ? []
+                  : [resolveAccessor(series.xAccessor!)(datum)],
+              )
+              .filter(isSampleValue)
           : [],
       );
       if (!("ticks" in base.xScale)) {

--- a/components/Chart/state/store/chart.store.ts
+++ b/components/Chart/state/store/chart.store.ts
@@ -4,6 +4,7 @@ import { resolveAccessor } from "../../utils/accessors";
 import { barGeometry, categoryAccessor, stackSeries } from "../../utils/bars";
 import { d3 } from "../../utils/d3";
 import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import { samplePosition } from "../../utils/sampleValidity";
 import {
   createScales,
   hasDomainOverride,
@@ -416,29 +417,35 @@ const refreshHover = (
       return [];
     }
     const datum = rows[index];
+    if (!scales.x || !scales.y) {
+      return [];
+    }
+    const xAccessor = item ? item.xAccessor : state.x;
+    const yAccessor = item ? item.yAccessor : state.y;
+    const sample = samplePosition(
+      datum,
+      xAccessor ? resolveAccessor(xAccessor) : () => index,
+      yAccessor ? resolveAccessor(yAccessor) : (value) => value,
+      scales.x,
+      scales.y,
+    );
+    if (!sample) {
+      return [];
+    }
     const geometry =
-      item?.type === "bar" && scales.x && scales.y
+      item?.type === "bar"
         ? barGeometry(item, datum, index, scales.x, scales.y)
         : null;
     const bar =
       geometry && bounded
         ? clipRectToPlot(geometry, state.dimensions)
         : geometry;
-    if (!scales.x || !scales.y || (item?.type === "bar" && !bar)) {
+    if (item?.type === "bar" && !bar) {
       return [];
     }
-    const xAccessor = item ? item.xAccessor : state.x;
-    const yAccessor = item ? item.yAccessor : state.y;
     const coordinate = bar
       ? { x: bar.x + bar.width / 2, y: bar.y + bar.height / 2 }
-      : {
-          x: (scales.x as (value: unknown) => number)(
-            xAccessor ? resolveAccessor(xAccessor)(datum) : index,
-          ),
-          y: (scales.y as (value: unknown) => number)(
-            yAccessor ? resolveAccessor(yAccessor)(datum) : datum,
-          ),
-        };
+      : sample;
     if (bounded && !isPointInPlot(coordinate, state.dimensions)) {
       return [];
     }

--- a/components/Chart/state/store/sampleValidity.test.ts
+++ b/components/Chart/state/store/sampleValidity.test.ts
@@ -1,0 +1,65 @@
+import { expect, it } from "vitest";
+
+import {
+  type HoverInteraction,
+  InteractionChannel,
+} from "../../types/interaction";
+import {
+  createChartStore,
+  registerSeries,
+  updateChartState,
+  upsertInteraction,
+} from "./chart.store";
+
+it.each([null, undefined, NaN, Infinity])(
+  "removes an active target when its value becomes %s",
+  (value) => {
+    const store = createChartStore({ width: 400, height: 300 }, "x", "y");
+    const data = [
+      { x: 0, y: 10 },
+      { x: 1, y: 20 },
+    ];
+    updateChartState(store, { data, dimensions: store.getState().dimensions });
+    registerSeries(store, "series", [
+      { id: "series", type: "line", x: "x", y: "y" },
+    ]);
+    upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+      targets: [{ seriesId: "series", dataIndex: 0, data: data[0] }],
+    });
+    updateChartState(store, {
+      data: [{ x: 0, y: value }, data[1]],
+      dimensions: store.getState().dimensions,
+    });
+    expect(
+      store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER),
+    ).toBeUndefined();
+  },
+);
+
+it("retains only the valid sibling at its original index after refresh", () => {
+  const store = createChartStore({ width: 400, height: 300 }, "x", "y");
+  updateChartState(store, {
+    data: [{ x: 0, y: 10 }],
+    dimensions: store.getState().dimensions,
+  });
+  registerSeries(store, "first", [{ id: "first", x: "x", y: "y" }]);
+  registerSeries(store, "second", [
+    { id: "second", x: "x", y: "y", data: [{ x: 0, y: 0 }] },
+  ]);
+  upsertInteraction(store, InteractionChannel.PRIMARY_HOVER, {
+    targets: [
+      { seriesId: "first", dataIndex: 0 },
+      { seriesId: "second", dataIndex: 0 },
+    ],
+  });
+  updateChartState(store, {
+    data: [{ x: 0, y: null }],
+    dimensions: store.getState().dimensions,
+  });
+  const hover = store
+    .getState()
+    .interactions.get(InteractionChannel.PRIMARY_HOVER) as HoverInteraction;
+  expect(
+    hover.targets.map(({ seriesId, dataIndex }) => [seriesId, dataIndex]),
+  ).toEqual([["second", 0]]);
+});

--- a/components/Chart/subcomponents/Announcer/Announcer.tsx
+++ b/components/Chart/subcomponents/Announcer/Announcer.tsx
@@ -46,22 +46,23 @@ export const Announcer: React.FC<AnnouncerProps> = ({ summaryId }) => {
   const getY = yAccessor ? resolveAccessor(yAccessor as any) : null;
 
   const summary = React.useMemo(() => {
-    if (!data?.length || !getX || !getY) {
+    const rows = data?.filter((datum) => datum != null);
+    if (!rows?.length || !getX || !getY) {
       return "Empty chart.";
     }
 
     const xLabel = config?.xAxisLabel || "X";
     const yLabel = config?.yAxisLabel || "Y";
-    const xValues = data.map((d) => getX(d));
+    const xValues = rows.map((d) => getX(d));
     if (horizontal) {
       const values = xValues.map(Number).filter(Number.isFinite);
-      const categories = data.map((d) => getY(d));
-      return `${type || "Bar"} chart with ${data.length} data points. ${xLabel} from ${Math.min(...values)} to ${Math.max(...values)}. ${yLabel} from ${describe(categories[0])} to ${describe(categories[categories.length - 1])}.`;
+      const categories = rows.map((d) => getY(d));
+      return `${type || "Bar"} chart with ${rows.length} data points. ${xLabel} from ${Math.min(...values)} to ${Math.max(...values)}. ${yLabel} from ${describe(categories[0])} to ${describe(categories[categories.length - 1])}.`;
     }
-    const yValues = data.map((d) => Number(getY(d))).filter(Number.isFinite);
+    const yValues = rows.map((d) => Number(getY(d))).filter(Number.isFinite);
 
     const parts = [
-      `${type || "Line"} chart with ${data.length} data points.`,
+      `${type || "Line"} chart with ${rows.length} data points.`,
       `${xLabel} from ${describe(xValues[0])} to ${describe(xValues[xValues.length - 1])}.`,
     ];
 

--- a/components/Chart/subcomponents/Announcer/Announcer.tsx
+++ b/components/Chart/subcomponents/Announcer/Announcer.tsx
@@ -5,6 +5,7 @@ import { resolveAccessor } from "../../types/accessors";
 import { InteractionChannel } from "../../types/interaction";
 import { categoryAccessor, valueAccessor } from "../../utils/bars";
 import { describeDatum } from "../../utils/describe";
+import { numericSample } from "../../utils/sampleValidity";
 import styles from "./Announcer.module.scss";
 
 interface AnnouncerProps {
@@ -55,11 +56,24 @@ export const Announcer: React.FC<AnnouncerProps> = ({ summaryId }) => {
     const yLabel = config?.yAxisLabel || "Y";
     const xValues = rows.map((d) => getX(d));
     if (horizontal) {
-      const values = xValues.map(Number).filter(Number.isFinite);
+      const values = xValues
+        .map(numericSample)
+        .filter((value) => value !== undefined);
       const categories = rows.map((d) => getY(d));
-      return `${type || "Bar"} chart with ${rows.length} data points. ${xLabel} from ${Math.min(...values)} to ${Math.max(...values)}. ${yLabel} from ${describe(categories[0])} to ${describe(categories[categories.length - 1])}.`;
+      const parts = [`${type || "Bar"} chart with ${rows.length} data points.`];
+      if (values.length) {
+        parts.push(
+          `${xLabel} from ${Math.min(...values)} to ${Math.max(...values)}.`,
+        );
+      }
+      parts.push(
+        `${yLabel} from ${describe(categories[0])} to ${describe(categories[categories.length - 1])}.`,
+      );
+      return parts.join(" ");
     }
-    const yValues = rows.map((d) => Number(getY(d))).filter(Number.isFinite);
+    const yValues = rows
+      .map((d) => numericSample(getY(d)))
+      .filter((value) => value !== undefined);
 
     const parts = [
       `${type || "Line"} chart with ${rows.length} data points.`,

--- a/components/Chart/subcomponents/Announcer/sampleValidity.test.tsx
+++ b/components/Chart/subcomponents/Announcer/sampleValidity.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+
+import { ChartContext } from "../../context";
+import { createChartStore } from "../../state/store/chart.store";
+import type { ContextValue } from "../../types";
+import { Announcer } from "./Announcer";
+
+afterEach(cleanup);
+
+it.each([false, true])(
+  "summarizes present rows without calling accessors on absent rows (horizontal=%s)",
+  (horizontal) => {
+    const chartStore = createChartStore({}, "x", "y");
+    chartStore.setState({
+      data: [null, { x: 1, y: 0 }, undefined, { x: 3, y: 20 }],
+      processedSeries: horizontal
+        ? [
+            {
+              id: "bar",
+              type: "bar",
+              orientation: "horizontal",
+              label: "Bar",
+              color: "red",
+            },
+          ]
+        : [],
+    });
+    const { container } = render(
+      <ChartContext.Provider value={{ chartStore } as ContextValue}>
+        <Announcer summaryId="summary" />
+      </ChartContext.Provider>,
+    );
+    expect(container.querySelector("#summary")?.textContent).toContain(
+      "2 data points",
+    );
+    expect(container.querySelector("#summary")?.textContent).toContain(
+      "X from 1 to 3",
+    );
+    expect(container.querySelector("#summary")?.textContent).toContain(
+      "Y from 0 to 20",
+    );
+  },
+);
+
+it("announces an empty chart when every row is absent", () => {
+  const chartStore = createChartStore({}, "x", "y");
+  chartStore.setState({ data: [null, undefined] });
+  const { container } = render(
+    <ChartContext.Provider value={{ chartStore } as ContextValue}>
+      <Announcer summaryId="summary" />
+    </ChartContext.Provider>,
+  );
+  expect(container.querySelector("#summary")?.textContent).toBe("Empty chart.");
+});

--- a/components/Chart/subcomponents/Announcer/sampleValidity.test.tsx
+++ b/components/Chart/subcomponents/Announcer/sampleValidity.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, expect, it } from "vitest";
 
 import { ChartContext } from "../../context";
@@ -53,3 +53,57 @@ it("announces an empty chart when every row is absent", () => {
   );
   expect(container.querySelector("#summary")?.textContent).toBe("Empty chart.");
 });
+
+const summaryCases = [
+  [[10, null, 20, undefined, NaN, Infinity, -Infinity], "from 10 to 20"],
+  [[0, null, 20], "from 0 to 20"],
+  [[undefined, NaN, Infinity, -Infinity], null],
+  [[null, undefined], null],
+] as const;
+
+it.each(
+  [false, true].flatMap((horizontal) =>
+    summaryCases.map(([values, range]) => ({ horizontal, values, range })),
+  ),
+)(
+  "uses only valid numeric samples in the summary (horizontal=$horizontal, values=$values)",
+  ({ horizontal, values, range }) => {
+    const chartStore = createChartStore(
+      {},
+      horizontal ? "value" : "category",
+      horizontal ? "category" : "value",
+    );
+    chartStore.setState({
+      processedSeries: horizontal
+        ? [
+            {
+              id: "bar",
+              type: "bar",
+              orientation: "horizontal",
+              label: "Bar",
+              color: "red",
+            },
+          ]
+        : [],
+    });
+    const { container } = render(
+      <ChartContext.Provider value={{ chartStore } as ContextValue}>
+        <Announcer summaryId="summary" />
+      </ChartContext.Provider>,
+    );
+
+    act(() =>
+      chartStore.setState({
+        data: values.map((value, index) => ({ category: `C${index}`, value })),
+      }),
+    );
+    const summary = container.querySelector("#summary")!.textContent!;
+    const axis = horizontal ? "X" : "Y";
+    if (range) {
+      expect(summary).toContain(`${axis} ${range}.`);
+    } else {
+      expect(summary).not.toContain(`${axis} from`);
+    }
+    expect(summary).not.toMatch(/NaN|Infinity/);
+  },
+);

--- a/components/Chart/subcomponents/BarSeries/BarSeries.test.tsx
+++ b/components/Chart/subcomponents/BarSeries/BarSeries.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as ChartContextModule from "../../context";
+import { d3 } from "../../utils/d3";
 import { BarSeriesWrapper } from "./BarSeries";
 
 // Mock the context hook
@@ -47,7 +48,10 @@ describe("BarSeries", () => {
         series: new Map(),
         processedSeries: [],
         interactions: new Map(),
-        scales: { x: (val: any) => val, y: (val: any) => val },
+        scales: {
+          x: d3.scaleBand().domain(["A", "B", "C"]).range([0, 440]),
+          y: d3.scaleLinear().domain([0, 20]).range([250, 0]),
+        },
         dimensions: {
           width: 500,
           height: 300,
@@ -68,7 +72,10 @@ describe("BarSeries", () => {
           series: new Map(),
           processedSeries: [],
           interactions: new Map(),
-          scales: { x: (val: any) => val, y: (val: any) => val },
+          scales: {
+            x: d3.scaleBand().domain(["A", "B", "C"]).range([0, 440]),
+            y: d3.scaleLinear().domain([0, 20]).range([250, 0]),
+          },
           dimensions: {
             width: 500,
             height: 300,
@@ -114,7 +121,10 @@ describe("BarSeries", () => {
             series: new Map(),
             processedSeries: [],
             interactions: new Map(),
-            scales: { x: (val: any) => val, y: (val: any) => val },
+            scales: {
+              x: d3.scaleBand().domain(["A", "B", "C"]).range([0, 440]),
+              y: d3.scaleLinear().domain([0, 20]).range([250, 0]),
+            },
             dimensions: {
               width: 300,
               height: 200,
@@ -146,7 +156,10 @@ describe("BarSeries", () => {
             series: new Map(),
             processedSeries: [],
             interactions: new Map(),
-            scales: { x: (val: any) => val, y: (val: any) => val },
+            scales: {
+              x: d3.scaleBand().domain(["A", "B", "C"]).range([0, 440]),
+              y: d3.scaleLinear().domain([0, 20]).range([250, 0]),
+            },
             dimensions: {
               width: 0,
               height: 0,

--- a/components/Chart/subcomponents/LineSeries/LineSeries.tsx
+++ b/components/Chart/subcomponents/LineSeries/LineSeries.tsx
@@ -14,6 +14,7 @@ import { resolveAccessor } from "../../utils/accessors";
 import { d3 } from "../../utils/d3";
 import { describeDatum } from "../../utils/describe";
 import { useSeriesColor } from "../../utils/hooks";
+import { samplePosition } from "../../utils/sampleValidity";
 import { SeriesPoint } from "../SeriesPoint/SeriesPoint";
 import styles from "./LineSeries.module.scss";
 
@@ -120,22 +121,28 @@ const LineSeriesComponent = <T,>({
       return null;
     }
 
+    const positions = Array.from(data, (datum) =>
+      samplePosition(datum, xAccessor, yAccessor, xScale, yScale),
+    );
+    type Position = { x: number; y: number } | null;
     const lineGenerator = d3
-      .line<T>()
-      .x((d) => (xScale as any)(xAccessor(d)) ?? 0)
-      .y((d) => ("ticks" in yScale ? yScale(Number(yAccessor(d))) : 0))
+      .line<Position>()
+      .defined((point) => point !== null)
+      .x((point) => point!.x)
+      .y((point) => point!.y)
       .curve(curve || config.curve || d3.curveLinear);
 
     const areaGenerator = d3
-      .area<T>()
-      .x((d) => (xScale as any)(xAccessor(d)) ?? 0)
+      .area<Position>()
+      .defined((point) => point !== null)
+      .x((point) => point!.x)
       .y0(innerHeight)
-      .y1((d) => ("ticks" in yScale ? yScale(Number(yAccessor(d))) : 0))
+      .y1((point) => point!.y)
       .curve(curve || config.curve || d3.curveLinear);
 
     return {
-      line: lineGenerator(data),
-      area: areaGenerator(data),
+      line: lineGenerator(positions),
+      area: areaGenerator(positions),
     };
   }, [
     xScale,
@@ -147,6 +154,7 @@ const LineSeriesComponent = <T,>({
     config.curve,
     dimensions.width,
     dimensions.height,
+    innerHeight,
   ]);
 
   if (render && xScale && yScale) {
@@ -228,16 +236,24 @@ const LineSeriesComponent = <T,>({
         yAccessor &&
         xAccessor &&
         data.map((d, i) => {
-          const cx = (xScale as any)(xAccessor(d));
-          const cy = "ticks" in yScale ? yScale(Number(yAccessor(d))) : 0;
+          const position = samplePosition(
+            d,
+            xAccessor,
+            yAccessor,
+            xScale,
+            yScale,
+          );
+          if (!position) {
+            return null;
+          }
           return (
             <SeriesPoint
               key={i}
               color={strokeColor}
               datum={d}
               description={describeDatum(d, xAccessor, yAccessor)}
-              x={cx}
-              y={cy}
+              x={position.x}
+              y={position.y}
             />
           );
         })}

--- a/components/Chart/subcomponents/LineSeries/sampleValidity.test.tsx
+++ b/components/Chart/subcomponents/LineSeries/sampleValidity.test.tsx
@@ -1,0 +1,148 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ChartContext } from "../../context";
+import { createChartStore } from "../../state/store/chart.store";
+import type { ContextValue } from "../../types";
+import { d3 } from "../../utils/d3";
+import { createScales } from "../../utils/scales";
+import { LineSeries } from "./LineSeries";
+
+type Row = { x: number | null; y: number | null | undefined };
+const margin = { top: 0, right: 0, bottom: 0, left: 0 };
+afterEach(cleanup);
+
+function draw(data: Row[], type: "line" | "area") {
+  const chartStore = createChartStore(
+    { width: 100, height: 100, margin },
+    "x",
+    "y",
+  );
+  chartStore.setState({
+    data,
+    scales: {
+      x: d3.scaleLinear().domain([0, 4]).range([0, 100]),
+      y: d3.scaleLinear().domain([0, 20]).range([100, 0]),
+    },
+  });
+  return render(
+    <ChartContext.Provider
+      value={{ chartStore, config: {}, x: "x", y: "y" } as ContextValue<Row>}
+    >
+      <svg>
+        <LineSeries showDots type={type} />
+      </svg>
+    </ChartContext.Provider>,
+  );
+}
+
+describe.each(["line", "area"] as const)("%s sample validity", (type) => {
+  it.each([
+    ["leading", [null, 10, 20], "M25,50L50,0"],
+    ["interior", [10, null, 20], "M0,50ZM50,0Z"],
+    ["trailing", [10, 20, undefined], "M0,50L25,0"],
+    ["nonfinite", [10, NaN, Infinity, -Infinity, 0], "M0,50ZM100,100Z"],
+    ["all invalid", [null, undefined, NaN, Infinity], ""],
+  ] as const)(
+    "gaps %s samples without inventing zero",
+    (_, values, expected) => {
+      const { container } = draw(
+        values.map((y, x) => ({ x, y })),
+        type,
+      );
+      expect(
+        container
+          .querySelector('[aria-roledescription="line"]')
+          ?.getAttribute("d"),
+      ).toBe(expected);
+      expect(container.querySelectorAll("circle")).toHaveLength(
+        values.filter((v) => typeof v === "number" && Number.isFinite(v))
+          .length,
+      );
+      for (const path of container.querySelectorAll("path")) {
+        expect(path.getAttribute("d")).not.toMatch(/NaN|Infinity/);
+        expect((path.getAttribute("d")?.match(/M/g) ?? []).length).toBe(
+          (expected.match(/M/g) ?? []).length,
+        );
+      }
+    },
+  );
+
+  it("keeps sparse holes as gaps without calling accessors on them", () => {
+    const data: Row[] = new Array(5);
+    data[1] = { x: 1, y: 10 };
+    data[3] = { x: 3, y: 0 };
+    const { container } = draw(data, type);
+    expect(
+      container
+        .querySelector('[aria-roledescription="line"]')
+        ?.getAttribute("d"),
+    ).toBe("M25,50ZM75,100Z");
+    expect(container.querySelectorAll("circle")).toHaveLength(2);
+  });
+
+  it("omits missing and nonfinite X positions", () => {
+    const { container } = draw(
+      [
+        { x: null, y: 10 },
+        { x: NaN, y: 20 },
+        { x: Infinity, y: 10 },
+        { x: 3, y: 0 },
+      ],
+      type,
+    );
+    expect(
+      container
+        .querySelector('[aria-roledescription="line"]')
+        ?.getAttribute("d"),
+    ).toBe("M75,100Z");
+    expect(container.querySelectorAll("circle")).toHaveLength(1);
+  });
+});
+
+it("infers numeric X from the first valid sample and preserves missing-Y X positions", () => {
+  const data: Row[] = new Array(5);
+  data[1] = { x: null, y: 10 };
+  data[2] = { x: 2, y: null };
+  data[4] = { x: 4, y: 20 };
+  const { xScale, yScale } = createScales(
+    data,
+    100,
+    100,
+    margin,
+    (d) => d.x as number,
+    (d) => d.y as number,
+  );
+  expect(xScale.domain()).toEqual([2, 4]);
+  expect(yScale.domain()).toEqual([0, 22]);
+});
+
+it("ignores absent rows without evaluating their accessors", () => {
+  const data = [null, { x: 2, y: 10 }, undefined, { x: 4, y: 20 }];
+  const { xScale } = createScales(
+    data,
+    100,
+    100,
+    margin,
+    (d) => d!.x,
+    (d) => d!.y,
+  );
+  expect(xScale.domain()).toEqual([2, 4]);
+});
+
+it("preserves categorical X and finite numeric-string Y compatibility", () => {
+  const data = [
+    { x: "A", y: "0" },
+    { x: "B", y: "20" },
+  ];
+  const { xScale, yScale } = createScales(
+    data,
+    100,
+    100,
+    margin,
+    (d) => d.x,
+    (d) => Number(d.y),
+  );
+  expect(xScale.domain()).toEqual(["A", "B"]);
+  expect(yScale.domain()).toEqual([0, 22]);
+});

--- a/components/Chart/subcomponents/Root/Root.tsx
+++ b/components/Chart/subcomponents/Root/Root.tsx
@@ -36,6 +36,7 @@ import { HoverInteraction } from "../../types/interaction";
 import { barGeometry } from "../../utils/bars";
 import { hasChildOfTypeDeep } from "../../utils/componentDetection";
 import { clipRectToPlot, isPointInPlot } from "../../utils/plotBounds";
+import { samplePosition } from "../../utils/sampleValidity";
 import { hasDomainOverride } from "../../utils/scales";
 import { Announcer } from "../Announcer";
 import { Axis } from "../Axis/Axis";
@@ -368,6 +369,16 @@ export function Root<T>({
                 : null;
 
             const points = seriesData.flatMap((d: any, i: number) => {
+              const sample = samplePosition(
+                d,
+                getX ?? (() => i),
+                getY ?? ((datum) => datum),
+                xScale,
+                yScale,
+              );
+              if (!sample) {
+                return [];
+              }
               const geometry =
                 series.type === "bar"
                   ? barGeometry(series, d, i, xScale, yScale)
@@ -379,27 +390,18 @@ export function Root<T>({
                 geometry && bounded
                   ? clipRectToPlot(geometry, dimensions)
                   : geometry;
-              if (geometry && !bar) {
+              if (series.type === "bar" && !bar) {
                 return [];
               }
-              const position = {
-                x: bar
-                  ? bar.x + bar.width / 2
-                  : (xScale((getX ? getX(d) : i) as any) ?? NaN),
-                y: bar
-                  ? bar.y + bar.height / 2
-                  : (yScale((getY ? getY(d) : d) as any) ?? NaN),
-              };
+              const position = bar
+                ? { x: bar.x + bar.width / 2, y: bar.y + bar.height / 2 }
+                : sample;
               if (bounded && !isPointInPlot(position, dimensions)) {
                 return [];
               }
               return {
-                x:
-                  (Number.isFinite(position.x) ? position.x : 0) +
-                  dimensions.margin.left,
-                y:
-                  (Number.isFinite(position.y) ? position.y : 0) +
-                  dimensions.margin.top,
+                x: position.x + dimensions.margin.left,
+                y: position.y + dimensions.margin.top,
                 data: d,
                 seriesId: series.id,
                 seriesColor: series.color,
@@ -419,18 +421,28 @@ export function Root<T>({
           const getX = x ? resolveAccessor(x) : null;
           const getY = y ? resolveAccessor(y) : null;
 
-          const points = data.map((d: any, i: number) => ({
-            x:
-              (xScale((getX ? getX(d) : i) as any) ?? 0) +
-              dimensions.margin.left,
-            y:
-              (yScale((getY ? getY(d) : d) as any) ?? 0) +
-              dimensions.margin.top,
-            data: d,
-            seriesId: "default",
-            seriesColor: null,
-            dataIndex: i,
-          }));
+          const points = data.flatMap((d: any, i: number) => {
+            const position = samplePosition(
+              d,
+              getX ?? (() => i),
+              getY ?? ((datum) => datum),
+              xScale,
+              yScale,
+            );
+            if (!position) {
+              return [];
+            }
+            return [
+              {
+                x: position.x + dimensions.margin.left,
+                y: position.y + dimensions.margin.top,
+                data: d,
+                seriesId: "default",
+                seriesColor: null,
+                dataIndex: i,
+              },
+            ];
+          });
           for (const point of points) {
             if (
               !(

--- a/components/Chart/subcomponents/ScatterSeries/ScatterSeries.tsx
+++ b/components/Chart/subcomponents/ScatterSeries/ScatterSeries.tsx
@@ -12,6 +12,7 @@ import { Accessor } from "../../types";
 import { resolveAccessor } from "../../utils/accessors";
 import { describeDatum } from "../../utils/describe";
 import { useSeriesColor } from "../../utils/hooks";
+import { numericSample, samplePosition } from "../../utils/sampleValidity";
 import { SeriesPoint } from "../SeriesPoint/SeriesPoint";
 
 interface ScatterSeriesProps<T> {
@@ -63,9 +64,14 @@ const ScatterSeriesComponent = <T,>({
     if (!data.length || !sizeAccessor) {
       return null;
     }
-    const maxVal = Math.max(
-      ...data.map((d) => (sizeAccessor(d) as number) || 0),
-    );
+    const sizes = data.flatMap((datum) => {
+      if (datum == null) {
+        return [];
+      }
+      const size = numericSample(sizeAccessor(datum));
+      return size === undefined || size < 0 ? [] : [size];
+    });
+    const maxVal = Math.max(0, ...sizes);
     // Use sqrt scale for circular area sizing (area ~ value)
     return (val: number) => {
       const normalized = Math.sqrt(val) / Math.sqrt(maxVal || 1);
@@ -120,12 +126,23 @@ const ScatterSeriesComponent = <T,>({
   return (
     <g className="chart-scatter-series">
       {data.map((d, i) => {
-        const cx = (xScale as any)(xAccessor(d));
-        const cy = "ticks" in yScale ? yScale(Number(yAccessor(d))) : 0;
+        const position = samplePosition(
+          d,
+          xAccessor,
+          yAccessor,
+          xScale,
+          yScale,
+        );
+        if (!position) {
+          return null;
+        }
 
         let radius = 6;
         if (rScale && sizeAccessor) {
-          radius = rScale(sizeAccessor(d));
+          const size = numericSample(sizeAccessor(d));
+          if (size !== undefined && size >= 0) {
+            radius = rScale(size);
+          }
         }
 
         return (
@@ -136,8 +153,8 @@ const ScatterSeriesComponent = <T,>({
             description={describeDatum(d, xAccessor, yAccessor)}
             hoverRadius={radius + 4}
             radius={radius}
-            x={cx}
-            y={cy}
+            x={position.x}
+            y={position.y}
             {...{
               [CHART_DATA_ATTRS.TYPE]: "scatter",
               [CHART_DATA_ATTRS.SERIES_ID]: seriesId,

--- a/components/Chart/subcomponents/ScatterSeries/sampleValidity.test.tsx
+++ b/components/Chart/subcomponents/ScatterSeries/sampleValidity.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ChartContext } from "../../context";
+import {
+  createChartStore,
+  updateChartState,
+} from "../../state/store/chart.store";
+import type { ContextValue } from "../../types";
+import { BarSeries } from "../BarSeries/BarSeries";
+import { ScatterSeries } from "./ScatterSeries";
+
+type Row = {
+  x: number | null;
+  y: number | null | undefined;
+  size: number | null | undefined;
+};
+const sparse: Row[] = new Array(60);
+sparse[1] = { x: 1, y: 10, size: 4 };
+sparse[58] = { x: 58, y: 0, size: 0 };
+const samples: [string, Row[], number[]][] = [
+  [
+    "nullable and nonfinite",
+    [10, null, undefined, NaN, Infinity, -Infinity, 0].map((y, x) => ({
+      x,
+      y,
+      size: 4,
+    })),
+    [0, 6],
+  ],
+  [
+    "invalid category/X",
+    [
+      { x: null, y: 10, size: 4 },
+      { x: Infinity, y: 10, size: 4 },
+      { x: 2, y: 0, size: 0 },
+    ],
+    [2],
+  ],
+  ["sparse large", sparse, [1, 58]],
+  [
+    "absent rows",
+    [
+      null,
+      { x: 1, y: 10, size: 4 },
+      undefined,
+      { x: 3, y: 0, size: 0 },
+    ] as unknown as Row[],
+    [1, 3],
+  ],
+  [
+    "invalid optional size",
+    [4, 0, null, undefined, NaN, Infinity, -1].map((size, x) => ({
+      x,
+      y: 10,
+      size,
+    })),
+    [0, 1, 2, 3, 4, 5, 6],
+  ],
+  ["all invalid", [null, NaN, Infinity].map((y, x) => ({ x, y, size: 4 })), []],
+];
+afterEach(cleanup);
+
+describe.each(["scatter", "bubble", "vertical bar", "horizontal bar"] as const)(
+  "%s sample validity",
+  (mode) => {
+    it.each(samples)(
+      "renders only original valid samples for %s",
+      (_, data, indices) => {
+        const bar = mode.includes("bar");
+        const horizontal = mode === "horizontal bar";
+        const chartStore = createChartStore(
+          { width: 400, height: 300, type: bar ? "bar" : "scatter" },
+          horizontal ? "y" : "x",
+          horizontal ? "x" : "y",
+        );
+        updateChartState(chartStore, {
+          data,
+          type: bar ? "bar" : "scatter",
+          dimensions: chartStore.getState().dimensions,
+        });
+        const { container } = render(
+          <ChartContext.Provider
+            value={
+              {
+                chartStore,
+                config: {},
+                x: horizontal ? "y" : "x",
+                y: horizontal ? "x" : "y",
+              } as ContextValue<Row>
+            }
+          >
+            <svg>
+              {bar ? (
+                <BarSeries
+                  orientation={horizontal ? "horizontal" : "vertical"}
+                  stackId="values"
+                />
+              ) : (
+                <ScatterSeries size={mode === "bubble" ? "size" : undefined} />
+              )}
+            </svg>
+          </ChartContext.Provider>,
+        );
+        const marks = container.querySelectorAll(
+          bar ? ".chart-bar" : ".chart-scatter-series circle",
+        );
+        expect(
+          Array.from(marks, (mark) =>
+            Number(mark.getAttribute("data-chart-index")),
+          ),
+        ).toEqual(indices);
+        for (const mark of marks) {
+          for (const attr of ["cx", "cy", "r", "d"]) {
+            expect(mark.getAttribute(attr) ?? "").not.toMatch(/NaN|Infinity/);
+          }
+          const index = Number(mark.getAttribute("data-chart-index"));
+          if (mode === "bubble") {
+            const size = data[index].size;
+            expect(Number(mark.getAttribute("r"))).toBe(
+              size === 4 ? 20 : size === 0 ? 4 : 6,
+            );
+          }
+          if (bar && data[index].y === 0) {
+            expect(mark.getAttribute("d")).toBe("");
+          }
+        }
+        expect(chartStore.getState().data).toBe(data);
+      },
+    );
+  },
+);

--- a/components/Chart/subcomponents/ScatterSeries/sampleValidity.test.tsx
+++ b/components/Chart/subcomponents/ScatterSeries/sampleValidity.test.tsx
@@ -97,7 +97,11 @@ describe.each(["scatter", "bubble", "vertical bar", "horizontal bar"] as const)(
                   stackId="values"
                 />
               ) : (
-                <ScatterSeries size={mode === "bubble" ? "size" : undefined} />
+                <ScatterSeries<Row>
+                  size={
+                    mode === "bubble" ? (row) => row.size as number : undefined
+                  }
+                />
               )}
             </svg>
           </ChartContext.Provider>,

--- a/components/Chart/utils/barSampleValidity.test.ts
+++ b/components/Chart/utils/barSampleValidity.test.ts
@@ -1,0 +1,120 @@
+import { expect, it } from "vitest";
+
+import {
+  createChartStore,
+  updateChartDimensions,
+} from "../state/store/chart.store";
+import { stackSeries } from "./bars";
+
+it.each([false, true])(
+  "derives finite bar domains without evaluating absent rows (horizontal=%s)",
+  (horizontal) => {
+    const store = createChartStore(
+      { type: "bar" },
+      horizontal ? "value" : "category",
+      horizontal ? "category" : "value",
+    );
+    store.setState({
+      processedSeries: [
+        {
+          id: "bar",
+          type: "bar",
+          orientation: horizontal ? "horizontal" : "vertical",
+          label: "bar",
+          color: "red",
+          xAccessor: horizontal ? "value" : "category",
+          yAccessor: horizontal ? "category" : "value",
+          data: [
+            null,
+            { category: "A", value: 10 },
+            undefined,
+            { category: null, value: 20 },
+          ],
+          stackRanges: [
+            [0, 0],
+            [0, 10],
+            [0, 0],
+            [0, 0],
+          ],
+        },
+      ],
+    });
+    updateChartDimensions(store, 400, 300);
+    expect(
+      (horizontal
+        ? store.getState().scales.y
+        : store.getState().scales.x)!.domain(),
+    ).toEqual(["A"]);
+  },
+);
+
+it("keeps stacked totals and indices intact across invalid and absent samples", () => {
+  const rows = [
+    null,
+    { category: "A", value: 10 },
+    { category: "A", value: Infinity },
+    { category: "A", value: 0 },
+    undefined,
+  ];
+  const [first, second] = stackSeries([
+    {
+      id: "first",
+      label: "first",
+      color: "red",
+      type: "bar",
+      stackId: "stack",
+      xAccessor: "category",
+      yAccessor: "value",
+      data: rows,
+    },
+    {
+      id: "second",
+      label: "second",
+      color: "red",
+      type: "bar",
+      stackId: "stack",
+      xAccessor: "category",
+      yAccessor: "value",
+      data: [{ category: "A", value: 5 }],
+    },
+  ]);
+  expect(first.data).toBe(rows);
+  expect(second.stackRanges).toEqual([[10, 15]]);
+  expect(first.stackRanges?.[3]).toEqual([10, 10]);
+});
+
+it("derives mixed bar and non-bar domains from present finite samples", () => {
+  const store = createChartStore({ type: "line" }, "category", "value");
+  store.setState({
+    data: [{ category: "A", value: 5 }],
+    processedSeries: [
+      {
+        id: "bar",
+        type: "bar",
+        label: "bar",
+        color: "red",
+        xAccessor: "category",
+        yAccessor: "value",
+        data: [{ category: "A", value: 10 }],
+        stackRanges: [[0, 10]],
+      },
+      {
+        id: "scatter",
+        type: "scatter",
+        label: "scatter",
+        color: "red",
+        xAccessor: "category",
+        yAccessor: "value",
+        data: [
+          null,
+          { category: "B", value: 20 },
+          undefined,
+          { category: null, value: NaN },
+        ],
+      },
+    ],
+  });
+  updateChartDimensions(store, 400, 300);
+  expect(store.getState().scales.x!.domain()).toEqual(["A", "B"]);
+  expect(store.getState().scales.y!.domain()).toEqual([0, 20]);
+});

--- a/components/Chart/utils/bars.ts
+++ b/components/Chart/utils/bars.ts
@@ -1,6 +1,7 @@
 import { Scale } from "../types/scales";
 import { Series } from "../types/series";
 import { resolveAccessor } from "./accessors";
+import { isSampleValue, numericSample } from "./sampleValidity";
 
 export const categoryAccessor = (series: Series) =>
   series.orientation === "horizontal" ? series.yAccessor : series.xAccessor;
@@ -40,12 +41,18 @@ export function stackSeries(series: Series[]): Series[] {
     const getCategory = resolveAccessor(category);
     const getValue = resolveAccessor(value);
     const stackRanges = (item.data ?? []).map((datum): [number, number] => {
-      const v = Number(getValue(datum));
+      if (datum == null) {
+        return [0, 0];
+      }
+      const v = numericSample(getValue(datum));
       const categoryKey = getCategory(datum);
+      if (v === undefined || !isSampleValue(categoryKey)) {
+        return [0, 0];
+      }
       const total = totals.get(categoryKey) ?? [0, 0];
       const sign = v < 0 ? 0 : 1;
       const start = item.stackId === undefined ? 0 : total[sign];
-      const end = start + (Number.isFinite(v) ? v : 0);
+      const end = start + v;
       total[sign] = end;
       totals.set(categoryKey, total);
       return [start, end];
@@ -64,7 +71,11 @@ export function stackSeries(series: Series[]): Series[] {
       if (item.stackId === undefined) {
         return true;
       }
-      const total = totals?.get(resolveAccessor(category)(item.data![index]));
+      const datum = item.data?.[index];
+      if (datum == null) {
+        return false;
+      }
+      const total = totals?.get(resolveAccessor(category)(datum));
       return start !== end && end === total?.[end < start ? 0 : 1];
     });
     return { ...item, stackEnds };
@@ -81,7 +92,11 @@ export function barGeometry(
   const horizontal = series.orientation === "horizontal";
   const category = categoryAccessor(series);
   const value = valueAccessor(series);
-  if (!category || !value) {
+  if (datum == null || !category || !value) {
+    return null;
+  }
+  const numericValue = numericSample(resolveAccessor(value)(datum));
+  if (numericValue === undefined) {
     return null;
   }
   const categoryScale = horizontal ? y : x;
@@ -90,6 +105,9 @@ export function barGeometry(
     return null;
   }
   const categoryValue = resolveAccessor(category)(datum);
+  if (!isSampleValue(categoryValue)) {
+    return null;
+  }
   // Scale unions have different input domains; category values are validated by the scale.
   const position = (categoryScale as (value: unknown) => number)(categoryValue);
   const bandwidth =
@@ -101,12 +119,12 @@ export function barGeometry(
       ? Math.max(0, series.barWidth)
       : automatic;
   const categoryStart = position + bandwidth / 2 - thickness / 2;
-  const range = series.stackRanges?.[index] ?? [
-    0,
-    Number(resolveAccessor(value)(datum)),
-  ];
+  const range = series.stackRanges?.[index] ?? [0, numericValue];
   const start = (valueScale as (value: number) => number)(range[0]);
   const end = (valueScale as (value: number) => number)(range[1]);
+  if (![categoryStart, thickness, start, end].every(Number.isFinite)) {
+    return null;
+  }
   return horizontal
     ? {
         x: Math.min(start, end),

--- a/components/Chart/utils/sampleValidity.ts
+++ b/components/Chart/utils/sampleValidity.ts
@@ -1,0 +1,46 @@
+import type { Scale } from "../types/scales";
+
+export function isSampleValue(value: unknown): value is string | number {
+  return (
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+export function numericSample(value: unknown): number | undefined {
+  if (!isSampleValue(value) || (typeof value === "string" && !value.trim())) {
+    return undefined;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function sampleCoordinate(value: unknown, scale: Scale): number | undefined {
+  if (!isSampleValue(value)) {
+    return undefined;
+  }
+  const input = "invert" in scale ? numericSample(value) : value;
+  if (input === undefined) {
+    return undefined;
+  }
+  const coordinate = (scale as (value: string | number) => number | undefined)(
+    input,
+  );
+  return Number.isFinite(coordinate) ? coordinate : undefined;
+}
+
+/** Validate before scaling: D3's numeric coercion would turn null into zero. */
+export function samplePosition<T>(
+  datum: T | null | undefined,
+  getX: (datum: T) => unknown,
+  getY: (datum: T) => unknown,
+  xScale: Scale,
+  yScale: Scale,
+): { x: number; y: number } | null {
+  if (datum == null) {
+    return null;
+  }
+  const x = sampleCoordinate(getX(datum), xScale);
+  const y = sampleCoordinate(getY(datum), yScale);
+  return x === undefined || y === undefined ? null : { x, y };
+}

--- a/components/Chart/utils/scales.ts
+++ b/components/Chart/utils/scales.ts
@@ -3,6 +3,7 @@ import { ScaleBand, ScaleLinear, ScalePoint, ScaleTime } from "d3-scale";
 import { AxisDomain } from "../types/props";
 import { Scale } from "../types/scales";
 import { d3 } from "./d3";
+import { isSampleValue, numericSample } from "./sampleValidity";
 
 export type ChartXScale =
   | ScaleLinear<number, number>
@@ -32,10 +33,12 @@ export function createScales<T>(
   const innerWidth = width - margin.left - margin.right;
   const innerHeight = height - margin.top - margin.bottom;
 
-  const xValues = data.map(x);
+  const xValues = data
+    .flatMap((datum) => (datum == null ? [] : [x(datum)]))
+    .filter(isSampleValue);
   let xScale: ChartXScale;
 
-  // Check first value type to determine scale type
+  // Missing samples must not decide whether the axis is numeric.
   const firstValue = xValues[0];
 
   if (typeof firstValue === "number") {
@@ -62,7 +65,10 @@ export function createScales<T>(
       .padding(0.1);
   }
 
-  const yValues = data.map(y);
+  const yValues = data.flatMap((datum) => {
+    const value = datum == null ? undefined : numericSample(y(datum));
+    return value === undefined ? [] : [value];
+  });
   const yScale = d3
     .scaleLinear()
     .domain(automaticYDomain(yValues))

--- a/skills/doom-design-system/components/chart.md
+++ b/skills/doom-design-system/components/chart.md
@@ -112,6 +112,14 @@ d3Config={{
 />
 ```
 
+Missing or nonfinite axis samples form gaps in line and area series and are
+omitted from scatter, bubble, and bar marks and interaction targets. Zero is a
+valid sample; a zero-valued bar retains its normal invisible geometry. Sparse
+arrays and absent rows are skipped safely, and hover/keyboard targets keep the
+original datum indices. For scatter with `size`, an invalid optional size uses
+the default point radius and does not affect the size range; size zero remains
+valid.
+
 ## Axis domains
 
 `xDomain` and `yDomain` are top-level props on both `Chart` and `Chart.Root`,

--- a/tests/browser/Chart/cartesian-validity.test.tsx
+++ b/tests/browser/Chart/cartesian-validity.test.tsx
@@ -1,0 +1,235 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { commands, page, userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { useChartContext } from "../../../components/Chart/context";
+import type { Store } from "../../../components/Chart/state/store/chart.store";
+import {
+  type HoverInteraction,
+  InteractionChannel,
+} from "../../../components/Chart/types";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+type Row = {
+  x: number | null;
+  y: number | null | undefined;
+  size: number | null | undefined;
+};
+const sparse: Row[] = new Array(60);
+sparse[1] = { x: 1, y: 10, size: 4 };
+sparse[58] = { x: 58, y: 0, size: 0 };
+const samples: [string, Row[], number[]][] = [
+  [
+    "nullable and nonfinite",
+    [10, null, undefined, NaN, Infinity, -Infinity, 0].map((y, x) => ({
+      x,
+      y,
+      size: 4,
+    })),
+    [0, 6],
+  ],
+  [
+    "invalid category/X",
+    [
+      { x: null, y: 10, size: 4 },
+      { x: Infinity, y: 10, size: 4 },
+      { x: 2, y: 0, size: 0 },
+    ],
+    [2],
+  ],
+  ["sparse large", sparse, [1, 58]],
+  [
+    "absent rows",
+    [
+      null,
+      { x: 1, y: 10, size: 4 },
+      undefined,
+      { x: 3, y: 0, size: 0 },
+    ] as unknown as Row[],
+    [1, 3],
+  ],
+  [
+    "invalid optional size",
+    [4, 0, null, undefined, NaN, Infinity, -1].map((size, x) => ({
+      x,
+      y: 10,
+      size,
+    })),
+    [0, 1, 2, 3, 4, 5, 6],
+  ],
+  ["all invalid", [null, NaN, Infinity].map((y, x) => ({ x, y, size: 4 })), []],
+];
+function Capture({ save }: { save: (value: Store) => void }) {
+  save(useChartContext().chartStore);
+  return null;
+}
+const hover = (store: Store) =>
+  store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER) as
+    | HoverInteraction<Row>
+    | undefined;
+beforeEach(() => page.viewport(1200, 700));
+afterEach(cleanup);
+
+describe.each(["scatter", "bubble", "vertical bar", "horizontal bar"] as const)(
+  "%s native sample validity",
+  (mode) => {
+    it.each(samples)(
+      "renders and targets only valid samples for %s",
+      async (_, data, indices) => {
+        let store!: Store;
+        const bar = mode.includes("bar");
+        const horizontal = mode === "horizontal bar";
+        const { container } = render(
+          <DesignSystemProvider>
+            <Chart.Root
+              data={data}
+              style={{ width: 600, height: 360 }}
+              type={bar ? "bar" : "scatter"}
+              x={horizontal ? "y" : "x"}
+              y={horizontal ? "x" : "y"}
+            >
+              <Chart.Plot>
+                <Capture
+                  save={(value) => {
+                    store = value;
+                  }}
+                />
+                <Chart.Series
+                  orientation={
+                    bar ? (horizontal ? "horizontal" : "vertical") : undefined
+                  }
+                  size={mode === "bubble" ? "size" : undefined}
+                  stackId={bar ? "values" : undefined}
+                  type={bar ? "bar" : "scatter"}
+                />
+              </Chart.Plot>
+            </Chart.Root>
+          </DesignSystemProvider>,
+        );
+        await expect
+          .poll(() => store.getState().dimensions.innerWidth)
+          .toBeGreaterThan(0);
+        const getMarks = () =>
+          Array.from(
+            container.querySelectorAll(
+              bar ? ".chart-bar" : ".chart-scatter-series circle",
+            ),
+          );
+        await expect
+          .poll(() =>
+            getMarks().map((mark) =>
+              Number(mark.getAttribute("data-chart-index")),
+            ),
+          )
+          .toEqual(indices);
+        for (const mark of getMarks()) {
+          for (const attr of ["cx", "cy", "r", "d"]) {
+            expect(mark.getAttribute(attr) ?? "").not.toMatch(/NaN|Infinity/);
+          }
+          const index = Number(mark.getAttribute("data-chart-index"));
+          if (mode === "bubble") {
+            const size = data[index].size;
+            expect(Number(mark.getAttribute("r"))).toBe(
+              size === 4 ? 20 : size === 0 ? 4 : 6,
+            );
+          }
+          if (bar && data[index].y === 0) {
+            expect(mark.getAttribute("d")).toBe("");
+            continue;
+          }
+          const box = mark.getBoundingClientRect();
+          const x =
+            box.left +
+            box.width / 2 +
+            (bar
+              ? 0
+              : Number(mark.getAttribute("cx")) <
+                  store.getState().dimensions.innerWidth / 2
+                ? 1
+                : -1);
+          const y =
+            box.top +
+            box.height / 2 +
+            (bar
+              ? 0
+              : Number(mark.getAttribute("cy")) <
+                  store.getState().dimensions.innerHeight / 2
+                ? 1
+                : -1);
+          expect(document.elementsFromPoint(x, y)).toContain(mark);
+          await commands.moveChartPointer(x, y);
+          await expect
+            .poll(() => hover(store)?.targets.map((target) => target.dataIndex))
+            .toEqual([index]);
+          expect(hover(store)?.targets[0].data).toBe(data[index]);
+        }
+        container.querySelector<HTMLElement>("[data-chart-container]")!.focus();
+        await userEvent.keyboard("{Escape}");
+        for (const index of indices) {
+          await userEvent.keyboard("{ArrowRight}");
+          expect(
+            hover(store)?.targets.map((target) => target.dataIndex),
+          ).toEqual([index]);
+        }
+        if (!indices.length) {
+          await userEvent.keyboard("{ArrowRight}");
+          expect(hover(store)).toBeUndefined();
+        }
+      },
+    );
+  },
+);
+
+it("prepares mixed bar/scatter domains without dereferencing absent series rows", async () => {
+  let store!: Store;
+  const { container } = render(
+    <DesignSystemProvider>
+      <Chart.Root
+        data={[{ category: "A", value: 5 }]}
+        style={{ width: 600, height: 360 }}
+        type="line"
+        x="category"
+        y="value"
+      >
+        <Chart.Plot>
+          <Capture
+            save={(value) => {
+              store = value;
+            }}
+          />
+          <Chart.Series data={[{ category: "A", value: 10 }]} type="bar" />
+          <Chart.Series
+            data={
+              [
+                null,
+                { category: "B", value: 20 },
+                undefined,
+                { category: null, value: NaN },
+              ] as unknown as { category: string; value: number }[]
+            }
+            type="scatter"
+          />
+        </Chart.Plot>
+      </Chart.Root>
+    </DesignSystemProvider>,
+  );
+  await expect
+    .poll(() => store.getState().scales.x?.domain())
+    .toEqual(["A", "B"]);
+  expect(store.getState().scales.y!.domain()).toEqual([0, 20]);
+  await expect
+    .poll(
+      () => container.querySelectorAll(".chart-scatter-series circle").length,
+    )
+    .toBe(1);
+  const mark = container.querySelector(".chart-scatter-series circle")!;
+  const box = mark.getBoundingClientRect();
+  await commands.moveChartPointer(
+    box.x + box.width / 2 - 1,
+    box.y + box.height / 2 + 1,
+  );
+  await expect.poll(() => hover(store)?.targets[0].dataIndex).toBe(1);
+});

--- a/tests/browser/Chart/coordinateCommands.ts
+++ b/tests/browser/Chart/coordinateCommands.ts
@@ -1,0 +1,22 @@
+import { defineBrowserCommand } from "@vitest/browser-playwright";
+
+export const moveChartPointer = defineBrowserCommand(
+  async ({ page, frame }, clientX: number, clientY: number) => {
+    const iframe = await (await frame()).frameElement();
+    const box = await iframe.boundingBox();
+    const width = await iframe.evaluate(
+      (el) => (el as HTMLIFrameElement).clientWidth,
+    );
+    if (!box || box.width !== width) {
+      throw new Error("Exact pointer tests require an unscaled runner iframe");
+    }
+    // Locator.hover truncates positions; mouse.move retains subpixel boundaries.
+    await page.mouse.move(box.x + clientX, box.y + clientY);
+  },
+);
+
+declare module "vitest/browser" {
+  interface BrowserCommands {
+    moveChartPointer: (clientX: number, clientY: number) => Promise<void>;
+  }
+}

--- a/tests/browser/Chart/sample-validity.test.tsx
+++ b/tests/browser/Chart/sample-validity.test.tsx
@@ -1,0 +1,262 @@
+import "../../../styles/globals.scss";
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { userEvent } from "vitest/browser";
+
+import { Chart } from "../../../components/Chart/Chart";
+import { useChartContext } from "../../../components/Chart/context";
+import type { Store } from "../../../components/Chart/state/store/chart.store";
+import {
+  type HoverInteraction,
+  InteractionChannel,
+} from "../../../components/Chart/types";
+import { DesignSystemProvider } from "../../../DesignSystemProvider";
+
+type Row = { x: number | null; y: number | null | undefined };
+afterEach(cleanup);
+function Capture({ save }: { save: (store: Store) => void }) {
+  save(useChartContext().chartStore);
+  return null;
+}
+const hover = (store: Store) =>
+  store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER) as
+    | HoverInteraction<Row>
+    | undefined;
+// Aim one pixel inside the plot; rounded pointer coordinates can fall outside
+// a fractional SVG endpoint even when Playwright targets the circle center.
+const hoverMark = (mark: Element, store: Store) =>
+  userEvent.hover(mark, {
+    position: {
+      x:
+        Number(mark.getAttribute("cx")) <
+        store.getState().dimensions.innerWidth / 2
+          ? 6
+          : 4,
+      y:
+        Number(mark.getAttribute("cy")) <
+        store.getState().dimensions.innerHeight / 2
+          ? 6
+          : 4,
+    },
+  });
+const sparse: Row[] = new Array(5);
+sparse[1] = { x: 1, y: 10 };
+sparse[3] = { x: 3, y: 0 };
+const cases: [string, Row[], number[], number][] = [
+  [
+    "leading",
+    [
+      { x: 0, y: null },
+      { x: 1, y: 10 },
+      { x: 2, y: 20 },
+    ],
+    [1, 2],
+    1,
+  ],
+  [
+    "interior",
+    [
+      { x: 0, y: 10 },
+      { x: 1, y: null },
+      { x: 2, y: 20 },
+    ],
+    [0, 2],
+    2,
+  ],
+  [
+    "trailing",
+    [
+      { x: 0, y: 10 },
+      { x: 1, y: 20 },
+      { x: 2, y: undefined },
+    ],
+    [0, 1],
+    1,
+  ],
+  [
+    "nonfinite",
+    [10, NaN, Infinity, -Infinity, 0].map((y, x) => ({ x, y })),
+    [0, 4],
+    2,
+  ],
+  [
+    "invalid X",
+    [
+      { x: null, y: 10 },
+      { x: NaN, y: 10 },
+      { x: Infinity, y: 10 },
+      { x: 3, y: 0 },
+    ],
+    [3],
+    1,
+  ],
+  [
+    "all invalid",
+    [null, undefined, NaN, Infinity].map((y, x) => ({ x, y })),
+    [],
+    0,
+  ],
+  ["sparse", sparse, [1, 3], 2],
+  ["all sparse", new Array<Row>(5), [], 0],
+  [
+    "absent rows",
+    [null, { x: 1, y: 0 }, undefined, { x: 3, y: 20 }] as unknown as Row[],
+    [1, 3],
+    2,
+  ],
+];
+
+function example(
+  data: Row[],
+  type: "line" | "area",
+  save: (store: Store) => void,
+  second?: Row[],
+) {
+  return (
+    <DesignSystemProvider>
+      <Chart.Root
+        d3Config={{ showDots: true, grid: false, showAxes: false }}
+        data={data}
+        style={{ width: 600, height: 360 }}
+        type={type}
+        x="x"
+        y="y"
+      >
+        <Chart.Plot>
+          <Capture save={save} />
+          <Chart.Series label="First" type={type} />
+          {second && <Chart.Series data={second} label="Second" type={type} />}
+        </Chart.Plot>
+      </Chart.Root>
+    </DesignSystemProvider>
+  );
+}
+
+describe.each(["line", "area"] as const)("%s validity in Chromium", (type) => {
+  it.each(cases)(
+    "renders %s gaps and limits hover/keyboard to original valid indices",
+    async (_, data, indices, segments) => {
+      let store!: Store;
+      const { container } = render(
+        example(data, type, (value) => {
+          store = value;
+        }),
+      );
+      await expect
+        .poll(() => store.getState().dimensions.innerWidth)
+        .toBeGreaterThan(0);
+      await expect
+        .poll(
+          () => container.querySelectorAll(".chart-line-series circle").length,
+        )
+        .toBe(indices.length);
+      for (const path of container.querySelectorAll<SVGPathElement>(
+        ".chart-line-series path",
+      )) {
+        expect(path.getAttribute("d")).not.toMatch(/NaN|Infinity/);
+        expect((path.getAttribute("d")?.match(/M/g) ?? []).length).toBe(
+          segments,
+        );
+        expect(Number.isFinite(path.getTotalLength())).toBe(true);
+      }
+      const marks = container.querySelectorAll(".chart-line-series circle");
+      for (let i = 0; i < marks.length; i++) {
+        await hoverMark(marks[i], store);
+        await expect
+          .poll(() => hover(store)?.targets.map((target) => target.dataIndex))
+          .toEqual([indices[i]]);
+        expect(hover(store)?.targets[0].data).toBe(data[indices[i]]);
+      }
+      container.querySelector<HTMLElement>("[data-chart-container]")!.focus();
+      await userEvent.keyboard("{Escape}");
+      for (const index of indices) {
+        await userEvent.keyboard("{ArrowRight}");
+        expect(hover(store)?.targets.map((target) => target.dataIndex)).toEqual(
+          [index],
+        );
+        expect(hover(store)?.targets[0].data).toBe(data[index]);
+      }
+      if (!indices.length) {
+        await userEvent.keyboard("{ArrowRight}");
+        expect(hover(store)).toBeUndefined();
+        await userEvent.hover(container.querySelector("svg")!);
+        expect(hover(store)?.targets ?? []).toEqual([]);
+      }
+    },
+  );
+});
+
+it("keeps valid sibling series in shared tooltips when the primary sample is missing", async () => {
+  let store!: Store;
+  const first = [
+    { x: 0, y: 10 },
+    { x: 1, y: null },
+    { x: 2, y: 20 },
+  ];
+  const second = [
+    { x: 0, y: 12 },
+    { x: 1, y: 0 },
+    { x: 2, y: NaN },
+  ];
+  const { container } = render(
+    example(
+      first,
+      "line",
+      (value) => {
+        store = value;
+      },
+      second,
+    ),
+  );
+  await expect
+    .poll(() => container.querySelectorAll(".chart-line-series").length)
+    .toBe(2);
+  const marks = container
+    .querySelectorAll(".chart-line-series")[1]
+    .querySelectorAll("circle");
+  await hoverMark(marks[0], store);
+  await expect.poll(() => hover(store)?.targets.length).toBe(2);
+  await hoverMark(marks[1], store);
+  await expect
+    .poll(() => hover(store)?.targets.map((target) => target.data))
+    .toEqual([second[1]]);
+  expect(
+    container.querySelector("[data-chart-tooltip]")?.textContent,
+  ).toContain("Second:0");
+  expect(
+    container.querySelector("[data-chart-tooltip]")?.textContent,
+  ).not.toContain("First");
+  container.querySelector<HTMLElement>("[data-chart-container]")!.focus();
+  await userEvent.keyboard("{Escape}{ArrowRight}{ArrowRight}");
+  expect(hover(store)?.targets.map((target) => target.data)).toEqual([
+    second[1],
+  ]);
+  await userEvent.keyboard("{ArrowRight}");
+  expect(hover(store)?.targets.map((target) => target.data)).toEqual([
+    first[2],
+  ]);
+});
+
+it("clears an active hover when its sample becomes invalid, and restores interaction with zero", async () => {
+  let store!: Store;
+  const save = (value: Store) => {
+    store = value;
+  };
+  const data = [
+    { x: 0, y: 10 },
+    { x: 1, y: 20 },
+  ];
+  const { container, rerender } = render(example(data, "line", save));
+  await expect.poll(() => container.querySelectorAll("circle").length).toBe(2);
+  await hoverMark(container.querySelector("circle")!, store);
+  await expect.poll(() => hover(store)?.targets[0].dataIndex).toBe(0);
+  rerender(example([{ x: 0, y: null }, data[1]], "line", save));
+  await expect.poll(() => hover(store)?.targets ?? []).toEqual([]);
+  rerender(example([{ x: 0, y: 0 }, data[1]], "line", save));
+  await expect
+    .poll(() => container.querySelectorAll(".chart-line-series circle").length)
+    .toBe(2);
+  await hoverMark(container.querySelector(".chart-line-series circle")!, store);
+  await expect.poll(() => hover(store)?.targets[0].data.y).toBe(0);
+});

--- a/tests/browser/Chart/sample-validity.test.tsx
+++ b/tests/browser/Chart/sample-validity.test.tsx
@@ -1,8 +1,8 @@
 import "../../../styles/globals.scss";
 
 import { cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
-import { userEvent } from "vitest/browser";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { commands, page, userEvent } from "vitest/browser";
 
 import { Chart } from "../../../components/Chart/Chart";
 import { useChartContext } from "../../../components/Chart/context";
@@ -14,6 +14,7 @@ import {
 import { DesignSystemProvider } from "../../../DesignSystemProvider";
 
 type Row = { x: number | null; y: number | null | undefined };
+beforeEach(() => page.viewport(1200, 700));
 afterEach(cleanup);
 function Capture({ save }: { save: (store: Store) => void }) {
   save(useChartContext().chartStore);
@@ -23,23 +24,24 @@ const hover = (store: Store) =>
   store.getState().interactions.get(InteractionChannel.PRIMARY_HOVER) as
     | HoverInteraction<Row>
     | undefined;
-// Aim one pixel inside the plot; rounded pointer coordinates can fall outside
-// a fractional SVG endpoint even when Playwright targets the circle center.
-const hoverMark = (mark: Element, store: Store) =>
-  userEvent.hover(mark, {
-    position: {
-      x:
-        Number(mark.getAttribute("cx")) <
-        store.getState().dimensions.innerWidth / 2
-          ? 6
-          : 4,
-      y:
-        Number(mark.getAttribute("cy")) <
-        store.getState().dimensions.innerHeight / 2
-          ? 6
-          : 4,
-    },
-  });
+// Stay inside the plot while accounting for browser-specific SVG stroke bounds.
+const hoverMark = (mark: Element, store: Store) => {
+  const box = mark.getBoundingClientRect();
+  return commands.moveChartPointer(
+    box.left +
+      box.width / 2 +
+      (Number(mark.getAttribute("cx")) <
+      store.getState().dimensions.innerWidth / 2
+        ? 1
+        : -1),
+    box.top +
+      box.height / 2 +
+      (Number(mark.getAttribute("cy")) <
+      store.getState().dimensions.innerHeight / 2
+        ? 1
+        : -1),
+  );
+};
 const sparse: Row[] = new Array(5);
 sparse[1] = { x: 1, y: 10 };
 sparse[3] = { x: 3, y: 0 };
@@ -133,7 +135,7 @@ function example(
   );
 }
 
-describe.each(["line", "area"] as const)("%s validity in Chromium", (type) => {
+describe.each(["line", "area"] as const)("%s sample validity", (type) => {
   it.each(cases)(
     "renders %s gaps and limits hover/keyboard to original valid indices",
     async (_, data, indices, segments) => {

--- a/tests/browser/Chart/sample-validity.test.tsx
+++ b/tests/browser/Chart/sample-validity.test.tsx
@@ -260,3 +260,58 @@ it("clears an active hover when its sample becomes invalid, and restores interac
   await hoverMark(container.querySelector(".chart-line-series circle")!, store);
   await expect.poll(() => hover(store)?.targets[0].data.y).toBe(0);
 });
+
+const summaryCases = [
+  [[10, null, 20, undefined, NaN, Infinity, -Infinity], "from 10 to 20"],
+  [[0, null, 20], "from 0 to 20"],
+  [[undefined, NaN, Infinity, -Infinity], null],
+  [[null, undefined], null],
+] as const;
+
+it.each(
+  [false, true].flatMap((horizontal) =>
+    summaryCases.map(([values, range]) => ({ horizontal, values, range })),
+  ),
+)(
+  "describes only valid numeric samples accessibly (horizontal=$horizontal, values=$values)",
+  async ({ horizontal, values, range }) => {
+    const renderSummary = (values: readonly (number | null | undefined)[]) => (
+      <DesignSystemProvider>
+        <Chart.Root
+          data={values.map((value, index) => ({
+            category: `C${index}`,
+            value,
+          }))}
+          style={{ width: 600, height: 360 }}
+          title="Sample summary"
+          type={horizontal ? "bar" : "line"}
+          x={horizontal ? "value" : "category"}
+          y={horizontal ? "category" : "value"}
+        >
+          <Chart.Plot>
+            <Chart.Series
+              orientation={horizontal ? "horizontal" : undefined}
+              type={horizontal ? "bar" : "line"}
+            />
+          </Chart.Plot>
+        </Chart.Root>
+      </DesignSystemProvider>
+    );
+    const { container, rerender } = render(renderSummary([10, null, 20]));
+
+    rerender(renderSummary(values));
+    const region = container.querySelector(
+      '[aria-label="Chart: Sample summary"]',
+    )!;
+    const summary = () =>
+      document.getElementById(region.getAttribute("aria-describedby")!)!
+        .textContent!;
+    const axis = horizontal ? "X" : "Y";
+    if (range) {
+      await expect.poll(summary).toContain(`${axis} ${range}.`);
+    } else {
+      await expect.poll(summary).not.toContain(`${axis} from`);
+    }
+    expect(summary()).not.toMatch(/NaN|Infinity/);
+  },
+);

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -1,6 +1,8 @@
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 
+import { moveChartPointer } from "./tests/browser/Chart/coordinateCommands";
+
 /**
  * Real-browser lane.
  *
@@ -14,6 +16,7 @@ export default defineConfig({
     include: ["tests/browser/**/*.test.tsx"],
     browser: {
       enabled: true,
+      commands: { moveChartPointer },
       provider: playwright(),
       headless: true,
       screenshotFailures: false,


### PR DESCRIPTION
Missing values could become zero, invalid SVG coordinates, or interactive targets. Shared sample validation now covers line/area gaps, scatter/bubble points, bar geometry and scales, hover refresh, keyboard targets, and accessible summaries. Valid zero and original datum indices are preserved.

Closes #87

Red/green regression coverage: 391 Chart unit tests and 159 focused browser checks across Chromium, Firefox, and WebKit passed. Production build and package verification passed. Defensive invalid-input fixtures also compose with the stricter accessor contract in #94.

Combined verification with the eight companion fixes: 1,028 unit tests, 554 Chart browser checks across three engines, 219 all-component Chromium checks, full typecheck, production build, and four package tests passed. All 235 Storybook tests passed. Added source comments were reviewed for necessity.

